### PR TITLE
Fix: reset.css가 하위 페이지에서 적용되지 않던 오류 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,44 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-		<link rel="stylesheet" href="./reset.css" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+<html lang="ko-KR">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>GameUs</title>
+		<!-- font : pretendard -->
+		<link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+	</head>
+	<body>
+		<div id="root"></div>
+	</body>
 </html>

--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,22 @@
+
+
+html {
+	font-size: 10px;
+}
+
+.a11y-hidden {
+	overflow: hidden;
+	position: absolute;
+	clip: rect(0, 0, 0, 0);
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	border: 0;
+	padding: 0;
+}
+
+.max-width{
+	max-width: 800px;
+	margin: 0 auto;
+	padding: 34px;
+}

--- a/src/components/organisms/LoginPageForm/LoginPageForm.jsx
+++ b/src/components/organisms/LoginPageForm/LoginPageForm.jsx
@@ -1,15 +1,15 @@
-import React from 'react'
+import React from "react";
 import LoginForm from "../../modules/LoginForm/LoginForm";
 
-function LoginPageForm({title, label}) {
+function LoginPageForm({ title, label }) {
   return (
     <section>
       <div className="max-width">
         <h1>{title}</h1>
-        <LoginForm label={label}/>
+        <LoginForm label={label} />
       </div>
     </section>
-  )
+  );
 }
 
-export default LoginPageForm
+export default LoginPageForm;

--- a/src/reset.css
+++ b/src/reset.css
@@ -127,24 +127,3 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
-
-html {
-	font-size: 10px;
-}
-
-.a11y-hidden {
-	overflow: hidden;
-	position: absolute;
-	clip: rect(0, 0, 0, 0);
-	width: 1px;
-	height: 1px;
-	margin: -1px;
-	border: 0;
-	padding: 0;
-}
-
-.max-width{
-	max-width: 800px;
-	margin: 0 auto;
-	padding: 34px;
-}


### PR DESCRIPTION
## 작업내용
reset.css 파일을 public 폴더에서 src 폴더로 옮기고, reset 관련이 아닌 전역적으로 적용할 스타일을 app.css로 분리하였습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
