### PR TITLE
Feat: 팔로워/팔로잉 목록에 들어갈 UserNameIntroduce 컴포넌트 및 css 구현

### DIFF
--- a/src/components/atoms/UserNameIntroduce/UserNameIntroduce.jsx
+++ b/src/components/atoms/UserNameIntroduce/UserNameIntroduce.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import styles from "./userNameIntroduce.module.css";
+
+function UserNameIntroduce({ userName, userIntroduce }) {
+  return (
+    <div>
+      <strong className={styles["user_name"]}>{userName}</strong>
+      <p className={styles["user_introduce"]}>{userIntroduce}</p>
+    </div>
+  );
+}
+
+export default UserNameIntroduce;

--- a/src/components/atoms/UserNameIntroduce/userNameIntroduce.module.css
+++ b/src/components/atoms/UserNameIntroduce/userNameIntroduce.module.css
@@ -1,0 +1,15 @@
+.user_name {
+  font-size: 1.4rem;
+  font-weight: 500;
+  line-height: 18px;
+}
+
+.user_introduce {
+  margin-top: 6px;
+  font-size: 1.2rem;
+  line-height: 15px;
+  color: #767676;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
## 작업내용
- #13 에서 필요한 사용자의 닉네임과 소개를 띄워주는 컴포넌트를 만들었습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
소개글은 길어질 수도 있기 때문에 `text-overflow: ellipsis;` 속성을 이용하여 말줄임표로 처리되게 하였습니다. 
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
