### PR TITLE
Feat: 팔로우/팔로잉 유저 정보를 보여주는 UserFollow 컴포넌트 및 css 구현

### DIFF
--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -24,32 +24,32 @@
 
 /* 사각형 이미지입니다. (갤러리 뷰에서만 사용되므로 size 클래스를 달지 않았습니다.) */
 .square {
-  width: 114px;
-  height: 114px;
+  max-width: 114px;
+  min-height: 114px;
 }
 
 /* 댓글에서 사용되는 프로필 이미지입니다. */
 .circle.small {
-  width: 36px;
-  height: 36px;
+  max-width: 36px;
+  min-height: 36px;
 }
 
 /* 게시글, 채팅에서 사용되닌 프로필 이미지입니다. */
 .circle.medium_small {
-  width: 42px;
-  height: 42px;
+  max-width: 42px;
+  min-height: 42px;
 }
 
 /* 팔로워 or 팔로잉 목록에서 사용되는 프로필 이미지입니다. */
 .circle.medium {
-  width: 50px;
-  height: 50px;
+  max-width: 50px;
+  min-height: 50px;
 }
 
 /* 회원 가입, 프로필 페이지에서 사용되는 프로필 이미지입니다. */
 .circle.large {
-  width: 110px;
-  height: 110px;
+  max-width: 110px;
+  min-height: 110px;
   border-width: 1px;
 }
 

--- a/src/components/modules/UserFollow/UserFollow.jsx
+++ b/src/components/modules/UserFollow/UserFollow.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+import UserNameIntroduce from "../../atoms/UserNameIntroduce/UserNameIntroduce";
+import Button from "../../atoms/Button/Button";
+import styles from "./userFollow.module.css";
+import { useState } from "react";
+
+function UserFollow({ src, userName, userIntroduce }) {
+  const [isFollowing, setIsFollowing] = useState(false);
+  return (
+    <div className={styles["follow-wrapper"]}>
+      <ImageBox src={src} type="circle" size="medium" alt="프로필 이미지" />
+      <UserNameIntroduce userName={userName} userIntroduce={userIntroduce} />
+      <Button
+        size="small"
+        label={isFollowing ? "취소" : "팔로우"}
+        active={true}
+        primary={isFollowing ? false : true}
+        onClick={() => setIsFollowing(!isFollowing)}
+      />
+    </div>
+  );
+}
+
+export default UserFollow;

--- a/src/components/modules/UserFollow/userFollow.module.css
+++ b/src/components/modules/UserFollow/userFollow.module.css
@@ -1,0 +1,18 @@
+.follow-wrapper {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  max-width: 358px;
+  margin: 0px auto;
+}
+
+.follow-wrapper > div:nth-child(2) {
+  max-width: 240px;
+  margin: 5px 0 6px 12px;
+}
+
+.follow-wrapper > button {
+  width: 56px;
+  justify-self: end;
+  margin-left: auto;
+}


### PR DESCRIPTION
## 작업내용
- #13 에서 필요한 유저 사진과 정보, 팔로우 버튼이 결합된 모듈을 만들었습니다.
## 레퍼런스
https://stackoverflow.com/questions/50746912/how-to-style-child-components-in-react-with-css-modules
## 중점적으로 봐주었으면 하는 부분
- 피그마를 그대로 따라해서 우선은 width가 고정값입니다.
- css 이슈는 레퍼런스 링크의 방법대로 우선 해결했지만, 더 나은 방법이 있는지 찾아보겠습니다!
- 이미지가 찌그러지는 문제가 있어서 임시방편으로 ImageBox의 circle 부분만 css를 max-width, min-height로 수정했습니다. (이미지 적용 전에 불러올 때 미리 잘라주는 방법을 사용해야 할 지도 모르겠습니다.)
- 테스트용으로 useState를 이용해서 버튼을 클릭할 때마다 팔로우/취소 로 바뀌도록 했습니다.
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
