### PR TITLE
Feat: 팔로워/팔로잉 수를 나타내는 컴포넌트 및 css 구현

### DIFF
--- a/src/components/atoms/NumberFollow/NumberFollow.jsx
+++ b/src/components/atoms/NumberFollow/NumberFollow.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import styles from "./numberFollow.module.css";
+
+function NumberFollow({ number, isFollower }) {
+  const classList = ["number"];
+  // 팔로잉의 수를 표시할 경우에는 색을 바꾸기 위해 following이라는 클래스가 추가로 붙습니다.
+  isFollower ? null : classList.push("following");
+  const CLASS_LIST = classList.map((item) => styles[item]).join(" ");
+
+  // 나중에 :accountname 추가해야 합니다.
+  const followerURL = "/profile/follower";
+  const followingURL = "/profile/following";
+
+  return (
+    <Link
+      to={isFollower ? followerURL : followingURL}
+      className={styles["wrapper"]}
+    >
+      <strong className={CLASS_LIST}>{number}</strong>
+      <p className={styles["text"]}>
+        {isFollower ? "Followers" : "Followings"}
+      </p>
+    </Link>
+  );
+}
+
+export default NumberFollow;

--- a/src/components/atoms/NumberFollow/numberFollow.module.css
+++ b/src/components/atoms/NumberFollow/numberFollow.module.css
@@ -1,0 +1,24 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+}
+
+.number {
+  font-weight: 700;
+  font-size: 1.8rem;
+  line-height: 23px;
+}
+
+.number.following {
+  color: var(--darkgray-color);
+}
+
+.text {
+  font-size: 0.8rem;
+  line-height: 10px;
+  color: var(--darkgray-color);
+}


### PR DESCRIPTION
## 작업내용
- #11 에서 보여질 팔로워/팔로잉 수를 나타내는 컴포넌트를 구현했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 이 컴포넌트는 링크라서 누르면 팔로워/팔로잉 페이지로 이동합니다.
- 원래 url에는 :accountname이 들어가는데, 아직 api까지 테스트하진 않아서 우선 빼놓았습니다.
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
