### PR TITLE
Feat: 유저 정보, 팔로워/팔로잉 수, 프로필 사진을 결합한 컴포넌트 및 css 구현

### DIFF
--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -8,7 +8,8 @@
 }
 
 .image img {
-  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: cover;
 }
 
@@ -24,32 +25,32 @@
 
 /* 사각형 이미지입니다. (갤러리 뷰에서만 사용되므로 size 클래스를 달지 않았습니다.) */
 .square {
-  max-width: 114px;
-  min-height: 114px;
+  width: 114px;
+  height: 114px;
 }
 
 /* 댓글에서 사용되는 프로필 이미지입니다. */
 .circle.small {
-  max-width: 36px;
-  min-height: 36px;
+  width: 36px;
+  height: 36px;
 }
 
 /* 게시글, 채팅에서 사용되닌 프로필 이미지입니다. */
 .circle.medium_small {
-  max-width: 42px;
-  min-height: 42px;
+  width: 42px;
+  height: 42px;
 }
 
 /* 팔로워 or 팔로잉 목록에서 사용되는 프로필 이미지입니다. */
 .circle.medium {
-  max-width: 50px;
-  min-height: 50px;
+  width: 50px;
+  height: 50px;
 }
 
 /* 회원 가입, 프로필 페이지에서 사용되는 프로필 이미지입니다. */
 .circle.large {
-  max-width: 110px;
-  min-height: 110px;
+  width: 110px;
+  height: 110px;
   border-width: 1px;
 }
 

--- a/src/components/modules/UserProfileBox/UserProfileBox.jsx
+++ b/src/components/modules/UserProfileBox/UserProfileBox.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import NumberFollow from "../../atoms/NumberFollow/NumberFollow";
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+import UserInfo from "../../atoms/UserInfo/UserInfo";
+import styles from "./userProfileBox.module.css";
+
+function UserProfileBox({
+  userName,
+  userId,
+  userIntroduce,
+  followerNumber,
+  followingNumber,
+}) {
+  return (
+    <div className={styles["profile-wrapper"]}>
+      <div className={styles["upper-wrapper"]}>
+        <NumberFollow number={followerNumber} isFollower={true} />
+        <ImageBox
+          src="http://www.paullab.co.kr/images/weniv-binky.png"
+          type="circle"
+          size="large"
+        />
+        <NumberFollow number={followingNumber} isFollower={false} />
+      </div>
+      <UserInfo
+        userName={userName}
+        userId={userId}
+        userIntroduce={userIntroduce}
+      />
+    </div>
+  );
+}
+
+export default UserProfileBox;

--- a/src/components/modules/UserProfileBox/userProfileBox.module.css
+++ b/src/components/modules/UserProfileBox/userProfileBox.module.css
@@ -1,0 +1,14 @@
+.profile-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 30px auto 24px;
+}
+
+.upper-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 42px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## 작업내용
- #11 의
![image](https://user-images.githubusercontent.com/79434205/178007002-a42b9b15-b395-4658-b1d8-2519daf95e49.png)
부분을 구현했습니다.

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 드디어 이미지가 안 찌그러지도록 css 수정을 마친 것 같은데, 추후에 댓글 등 다른 곳에서 테스트 부탁드립니다!
- 커밋하고 알았는데 이미지에 alt값을 안 넣었어요. 나중에 꼭 넣겠습니다!
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
