### PR TITLE
Feat: 유저 프로필 하단의 버튼이 결합된 컴포넌트 구현

### DIFF
--- a/src/assets/icon-message-circle.svg
+++ b/src/assets/icon-message-circle.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.6665 1.66663H3.33317H1.66651H1.6665V3.33329H1.66651V18.3333H3.33317V3.33329H16.6665V13.3333H4.99984V15H3.33338V16.6666H5.00004V15H16.6665H18.3332V13.3333V3.33329V1.66663H16.6665Z" fill="#767676"/>
+</svg>

--- a/src/assets/icon-share.svg
+++ b/src/assets/icon-share.svg
@@ -1,0 +1,9 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.5" y="7.5" width="5" height="5" stroke="#767676"/>
+<rect x="11.5" y="1.5" width="5" height="5" stroke="#767676"/>
+<rect x="11.5" y="13.5" width="5" height="5" stroke="#767676"/>
+<rect x="7" y="6" width="2" height="2" fill="#767676"/>
+<rect x="7" y="12" width="2" height="2" fill="#767676"/>
+<rect x="9" y="5" width="2" height="2" fill="#767676"/>
+<rect x="9" y="13" width="2" height="2" fill="#767676"/>
+</svg>

--- a/src/components/atoms/IconButton/IconButton.jsx
+++ b/src/components/atoms/IconButton/IconButton.jsx
@@ -1,4 +1,4 @@
-import styles from "./IconButton.module.css";
+import styles from "./iconButton.module.css";
 
 function IconButton({ type, text, onClick }) {
   return (

--- a/src/components/atoms/IconButton/IconButton.module.css
+++ b/src/components/atoms/IconButton/IconButton.module.css
@@ -1,21 +1,37 @@
-.button{
+.button {
   width: 24px;
   height: 24px;
-  border:none;
+  border: none;
   background-color: transparent;
   background-position: center;
   background-repeat: no-repeat;
   cursor: pointer;
 }
 
-.back{
+.back {
   background-image: url(../../../assets/icon-arrow-left.svg);
 }
 
-.search{
+.search {
   background-image: url(../../../assets/icon-search.svg);
 }
 
-.menu{
+.menu {
   background-image: url(../../../assets/icon-more-vertical.svg);
+}
+
+.message {
+  background-image: url(../../../assets/icon-message-circle.svg);
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--lightgray-color);
+  border-radius: 30px;
+}
+
+.share {
+  background-image: url(../../../assets/icon-share.svg);
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--lightgray-color);
+  border-radius: 30px;
 }

--- a/src/components/modules/MyProfileButton/MyProfileButton.jsx
+++ b/src/components/modules/MyProfileButton/MyProfileButton.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import Button from "../../atoms/Button/Button";
+import styles from "./myProfileButton.module.css";
+
+function MyProfileButton() {
+  return (
+    <div className={styles["button-wrapper"]}>
+      <Button
+        href="#"
+        size="medium"
+        label="프로필 수정"
+        active={true}
+        primary={false}
+      />
+      <Button
+        href="#"
+        size="medium"
+        label="상품 등록"
+        active={true}
+        primary={false}
+      />
+    </div>
+  );
+}
+
+export default MyProfileButton;

--- a/src/components/modules/MyProfileButton/myProfileButton.module.css
+++ b/src/components/modules/MyProfileButton/myProfileButton.module.css
@@ -1,0 +1,14 @@
+.button-wrapper {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin: 0 91px;
+}
+
+.button-wrapper > a:first-child {
+  width: 120px;
+}
+
+.button-wrapper > a:last-child {
+  width: 100px;
+}

--- a/src/components/modules/ProfileButton/ProfileButton.jsx
+++ b/src/components/modules/ProfileButton/ProfileButton.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Button from "../../atoms/Button/Button";
+import IconButton from "../../atoms/IconButton/IconButton";
+import styles from "./profileButton.module.css";
+
+function ProfileButton({ isFollowing }) {
+  return (
+    <div className={styles["button-wrapper"]}>
+      <IconButton type="message" text="메시지 보내기" />
+      <Button
+        href="#"
+        size="medium"
+        label={isFollowing ? "언팔로우" : "팔로우"}
+        active={true}
+        primary={isFollowing ? false : true}
+      />
+      <IconButton type="share" text="공유하기" />
+    </div>
+  );
+}
+
+export default ProfileButton;

--- a/src/components/modules/ProfileButton/profileButton.module.css
+++ b/src/components/modules/ProfileButton/profileButton.module.css
@@ -1,0 +1,10 @@
+.button-wrapper {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin: 0 84px;
+}
+
+.button-wrapper > a {
+  width: 120px;
+}


### PR DESCRIPTION
## 작업내용
- #11 에서
![image](https://user-images.githubusercontent.com/79434205/178009947-c9d1f015-c411-41ad-a312-0fb69aeee940.png)
![image](https://user-images.githubusercontent.com/79434205/178009971-ccc8f15b-48e9-4c31-b82d-8a8a39e40a98.png)
부분을 구현했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 나의 프로필 페이지에서는 MyProfileButton 컴포넌트가, 타인의 프로필 페이지에서는 ProfileButton 컴포넌트가 보이게 됩니다.
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
