### PR TITLE
Feat: 사용자 프로필 컴포넌트, css 구현 및 페이지 생성

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,9 @@
 import { Routes, Route } from "react-router-dom";
 import LoginPage from "./pages/LoginPage/LoginPage";
 import JoinPage from "./pages/JoinPage";
+import ProfilePage from "./pages/ProfilePage";
 import "./reset.css";
 import "./global.css";
-
 function App() {
   return (
     <div className="max-width">
@@ -11,6 +11,15 @@ function App() {
         <Route path="/" element={<h1>메인 페이지입니다.</h1>} />
         <Route path="/user/login" element={<LoginPage />} />
         <Route path="/user" element={<JoinPage />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route
+          path="/profile/follower"
+          element={<h1>팔로워 목록 페이지입니다.</h1>}
+        />
+        <Route
+          path="/profile/following"
+          element={<h1>팔로잉 목록 페이지입니다.</h1>}
+        />
       </Routes>
     </div>
   );

--- a/src/assets/icon-message-circle.svg
+++ b/src/assets/icon-message-circle.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.6665 1.66663H3.33317H1.66651H1.6665V3.33329H1.66651V18.3333H3.33317V3.33329H16.6665V13.3333H4.99984V15H3.33338V16.6666H5.00004V15H16.6665H18.3332V13.3333V3.33329V1.66663H16.6665Z" fill="#767676"/>
+</svg>

--- a/src/assets/icon-share.svg
+++ b/src/assets/icon-share.svg
@@ -1,0 +1,9 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.5" y="7.5" width="5" height="5" stroke="#767676"/>
+<rect x="11.5" y="1.5" width="5" height="5" stroke="#767676"/>
+<rect x="11.5" y="13.5" width="5" height="5" stroke="#767676"/>
+<rect x="7" y="6" width="2" height="2" fill="#767676"/>
+<rect x="7" y="12" width="2" height="2" fill="#767676"/>
+<rect x="9" y="5" width="2" height="2" fill="#767676"/>
+<rect x="9" y="13" width="2" height="2" fill="#767676"/>
+</svg>

--- a/src/components/atoms/IconButton/IconButton.jsx
+++ b/src/components/atoms/IconButton/IconButton.jsx
@@ -1,4 +1,4 @@
-import styles from "./IconButton.module.css";
+import styles from "./iconButton.module.css";
 
 function IconButton({ type, text, onClick }) {
   return (

--- a/src/components/atoms/IconButton/IconButton.module.css
+++ b/src/components/atoms/IconButton/IconButton.module.css
@@ -1,21 +1,37 @@
-.button{
+.button {
   width: 24px;
   height: 24px;
-  border:none;
+  border: none;
   background-color: transparent;
   background-position: center;
   background-repeat: no-repeat;
   cursor: pointer;
 }
 
-.back{
+.back {
   background-image: url(../../../assets/icon-arrow-left.svg);
 }
 
-.search{
+.search {
   background-image: url(../../../assets/icon-search.svg);
 }
 
-.menu{
+.menu {
   background-image: url(../../../assets/icon-more-vertical.svg);
+}
+
+.message {
+  background-image: url(../../../assets/icon-message-circle.svg);
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--lightgray-color);
+  border-radius: 30px;
+}
+
+.share {
+  background-image: url(../../../assets/icon-share.svg);
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--lightgray-color);
+  border-radius: 30px;
 }

--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -8,7 +8,8 @@
 }
 
 .image img {
-  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: cover;
 }
 
@@ -24,32 +25,32 @@
 
 /* 사각형 이미지입니다. (갤러리 뷰에서만 사용되므로 size 클래스를 달지 않았습니다.) */
 .square {
-  max-width: 114px;
-  min-height: 114px;
+  width: 114px;
+  height: 114px;
 }
 
 /* 댓글에서 사용되는 프로필 이미지입니다. */
 .circle.small {
-  max-width: 36px;
-  min-height: 36px;
+  width: 36px;
+  height: 36px;
 }
 
 /* 게시글, 채팅에서 사용되닌 프로필 이미지입니다. */
 .circle.medium_small {
-  max-width: 42px;
-  min-height: 42px;
+  width: 42px;
+  height: 42px;
 }
 
 /* 팔로워 or 팔로잉 목록에서 사용되는 프로필 이미지입니다. */
 .circle.medium {
-  max-width: 50px;
-  min-height: 50px;
+  width: 50px;
+  height: 50px;
 }
 
 /* 회원 가입, 프로필 페이지에서 사용되는 프로필 이미지입니다. */
 .circle.large {
-  max-width: 110px;
-  min-height: 110px;
+  width: 110px;
+  height: 110px;
   border-width: 1px;
 }
 

--- a/src/components/atoms/NumberFollow/NumberFollow.jsx
+++ b/src/components/atoms/NumberFollow/NumberFollow.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import styles from "./numberFollow.module.css";
+
+function NumberFollow({ number, isFollower }) {
+  const classList = ["number"];
+  // 팔로잉의 수를 표시할 경우에는 색을 바꾸기 위해 following이라는 클래스가 추가로 붙습니다.
+  isFollower ? null : classList.push("following");
+  const CLASS_LIST = classList.map((item) => styles[item]).join(" ");
+
+  // 나중에 :accountname 추가해야 합니다.
+  const followerURL = "/profile/follower";
+  const followingURL = "/profile/following";
+
+  return (
+    <Link
+      to={isFollower ? followerURL : followingURL}
+      className={styles["wrapper"]}
+    >
+      <strong className={CLASS_LIST}>{number}</strong>
+      <p className={styles["text"]}>
+        {isFollower ? "Followers" : "Followings"}
+      </p>
+    </Link>
+  );
+}
+
+export default NumberFollow;

--- a/src/components/atoms/NumberFollow/numberFollow.module.css
+++ b/src/components/atoms/NumberFollow/numberFollow.module.css
@@ -1,0 +1,24 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+}
+
+.number {
+  font-weight: 700;
+  font-size: 1.8rem;
+  line-height: 23px;
+}
+
+.number.following {
+  color: var(--darkgray-color);
+}
+
+.text {
+  font-size: 0.8rem;
+  line-height: 10px;
+  color: var(--darkgray-color);
+}

--- a/src/components/modules/MyProfileButton/MyProfileButton.jsx
+++ b/src/components/modules/MyProfileButton/MyProfileButton.jsx
@@ -4,7 +4,7 @@ import styles from "./myProfileButton.module.css";
 
 function MyProfileButton() {
   return (
-    <div className={styles["button-wrapper"]}>
+    <div className={styles["container-button"]}>
       <Button
         href="#"
         size="medium"

--- a/src/components/modules/MyProfileButton/MyProfileButton.jsx
+++ b/src/components/modules/MyProfileButton/MyProfileButton.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import Button from "../../atoms/Button/Button";
+import styles from "./myProfileButton.module.css";
+
+function MyProfileButton() {
+  return (
+    <div className={styles["button-wrapper"]}>
+      <Button
+        href="#"
+        size="medium"
+        label="프로필 수정"
+        active={true}
+        primary={false}
+      />
+      <Button
+        href="#"
+        size="medium"
+        label="상품 등록"
+        active={true}
+        primary={false}
+      />
+    </div>
+  );
+}
+
+export default MyProfileButton;

--- a/src/components/modules/MyProfileButton/myProfileButton.module.css
+++ b/src/components/modules/MyProfileButton/myProfileButton.module.css
@@ -1,14 +1,14 @@
-.button-wrapper {
+.container-button {
   display: flex;
   gap: 12px;
   justify-content: center;
   margin: 0 91px;
 }
 
-.button-wrapper > a:first-child {
+.container-button > a:first-child {
   width: 120px;
 }
 
-.button-wrapper > a:last-child {
+.container-button > a:last-child {
   width: 100px;
 }

--- a/src/components/modules/MyProfileButton/myProfileButton.module.css
+++ b/src/components/modules/MyProfileButton/myProfileButton.module.css
@@ -1,0 +1,14 @@
+.button-wrapper {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin: 0 91px;
+}
+
+.button-wrapper > a:first-child {
+  width: 120px;
+}
+
+.button-wrapper > a:last-child {
+  width: 100px;
+}

--- a/src/components/modules/ProfileButton/ProfileButton.jsx
+++ b/src/components/modules/ProfileButton/ProfileButton.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Button from "../../atoms/Button/Button";
+import IconButton from "../../atoms/IconButton/IconButton";
+import styles from "./profileButton.module.css";
+
+function ProfileButton({ isFollowing }) {
+  return (
+    <div className={styles["button-wrapper"]}>
+      <IconButton type="message" text="메시지 보내기" />
+      <Button
+        href="#"
+        size="medium"
+        label={isFollowing ? "언팔로우" : "팔로우"}
+        active={true}
+        primary={isFollowing ? false : true}
+      />
+      <IconButton type="share" text="공유하기" />
+    </div>
+  );
+}
+
+export default ProfileButton;

--- a/src/components/modules/ProfileButton/ProfileButton.jsx
+++ b/src/components/modules/ProfileButton/ProfileButton.jsx
@@ -5,7 +5,7 @@ import styles from "./profileButton.module.css";
 
 function ProfileButton({ isFollowing }) {
   return (
-    <div className={styles["button-wrapper"]}>
+    <div className={styles["container-button"]}>
       <IconButton type="message" text="메시지 보내기" />
       <Button
         href="#"

--- a/src/components/modules/ProfileButton/profileButton.module.css
+++ b/src/components/modules/ProfileButton/profileButton.module.css
@@ -1,0 +1,10 @@
+.button-wrapper {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin: 0 84px;
+}
+
+.button-wrapper > a {
+  width: 120px;
+}

--- a/src/components/modules/ProfileButton/profileButton.module.css
+++ b/src/components/modules/ProfileButton/profileButton.module.css
@@ -1,10 +1,10 @@
-.button-wrapper {
+.container-button {
   display: flex;
   gap: 10px;
   justify-content: center;
   margin: 0 84px;
 }
 
-.button-wrapper > a {
+.container-button > a {
   width: 120px;
 }

--- a/src/components/modules/UserProfileBox/UserProfileBox.jsx
+++ b/src/components/modules/UserProfileBox/UserProfileBox.jsx
@@ -13,8 +13,8 @@ function UserProfileBox({
   followingCount,
 }) {
   return (
-    <div className={styles["profile-wrapper"]}>
-      <div className={styles["upper-wrapper"]}>
+    <div className={styles["wrapper-profile"]}>
+      <div className={styles["wrapper-upper"]}>
         <NumberFollow number={followerCount} isFollower={true} />
         <ImageBox
           src={src}

--- a/src/components/modules/UserProfileBox/UserProfileBox.jsx
+++ b/src/components/modules/UserProfileBox/UserProfileBox.jsx
@@ -5,22 +5,23 @@ import UserInfo from "../../atoms/UserInfo/UserInfo";
 import styles from "./userProfileBox.module.css";
 
 function UserProfileBox({
+  src,
   userName,
   userId,
   userIntroduce,
-  followerNumber,
-  followingNumber,
+  followerCount,
+  followingCount,
 }) {
   return (
     <div className={styles["profile-wrapper"]}>
       <div className={styles["upper-wrapper"]}>
-        <NumberFollow number={followerNumber} isFollower={true} />
+        <NumberFollow number={followerCount} isFollower={true} />
         <ImageBox
-          src="http://www.paullab.co.kr/images/weniv-binky.png"
+          src={src}
           type="circle"
           size="large"
         />
-        <NumberFollow number={followingNumber} isFollower={false} />
+        <NumberFollow number={followingCount} isFollower={false} />
       </div>
       <UserInfo
         userName={userName}

--- a/src/components/modules/UserProfileBox/UserProfileBox.jsx
+++ b/src/components/modules/UserProfileBox/UserProfileBox.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import NumberFollow from "../../atoms/NumberFollow/NumberFollow";
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+import UserInfo from "../../atoms/UserInfo/UserInfo";
+import styles from "./userProfileBox.module.css";
+
+function UserProfileBox({
+  userName,
+  userId,
+  userIntroduce,
+  followerNumber,
+  followingNumber,
+}) {
+  return (
+    <div className={styles["profile-wrapper"]}>
+      <div className={styles["upper-wrapper"]}>
+        <NumberFollow number={followerNumber} isFollower={true} />
+        <ImageBox
+          src="http://www.paullab.co.kr/images/weniv-binky.png"
+          type="circle"
+          size="large"
+        />
+        <NumberFollow number={followingNumber} isFollower={false} />
+      </div>
+      <UserInfo
+        userName={userName}
+        userId={userId}
+        userIntroduce={userIntroduce}
+      />
+    </div>
+  );
+}
+
+export default UserProfileBox;

--- a/src/components/modules/UserProfileBox/userProfileBox.module.css
+++ b/src/components/modules/UserProfileBox/userProfileBox.module.css
@@ -1,0 +1,14 @@
+.profile-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 30px auto 24px;
+}
+
+.upper-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 42px;
+  margin: 0 auto;
+}

--- a/src/components/modules/UserProfileBox/userProfileBox.module.css
+++ b/src/components/modules/UserProfileBox/userProfileBox.module.css
@@ -1,11 +1,11 @@
-.profile-wrapper {
+.wrapper-profile {
   display: flex;
   flex-direction: column;
   gap: 16px;
   margin: 30px auto 24px;
 }
 
-.upper-wrapper {
+.wrapper-upper {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import UserProfileBox from "../../modules/UserProfileBox/UserProfileBox";
+import MyProfileButton from "../../modules/MyProfileButton/MyProfileButton";
+import ProfileButton from "../../modules/ProfileButton/ProfileButton";
+
+function UserProfile({ isMe }) {
+  return (
+    <div>
+      <UserProfileBox
+        userName="애월읍 위니브 게임랜드"
+        userId="weniv_Gameland"
+        userIntroduce="제주 최고의 게임랜드를 찾으시나요?"
+        followerNumber={2950}
+        followingNumber={128}
+      />
+      {isMe ? <MyProfileButton /> : <ProfileButton isFollowing={true} />}
+    </div>
+  );
+}
+
+export default UserProfile;

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -3,17 +3,18 @@ import UserProfileBox from "../../modules/UserProfileBox/UserProfileBox";
 import MyProfileButton from "../../modules/MyProfileButton/MyProfileButton";
 import ProfileButton from "../../modules/ProfileButton/ProfileButton";
 
-function UserProfile({ isMe }) {
+function UserProfile({ isMe, user }) {
   return (
     <div>
       <UserProfileBox
-        userName="애월읍 위니브 게임랜드"
-        userId="weniv_Gameland"
-        userIntroduce="제주 최고의 게임랜드를 찾으시나요?"
-        followerNumber={2950}
-        followingNumber={128}
+        src={user.image}
+        userName={user.username}
+        userId={user.accountname}
+        userIntroduce={user.intro}
+        followerCount={user.followerCount}
+        followingCount={user.followingCount}
       />
-      {isMe ? <MyProfileButton /> : <ProfileButton isFollowing={true} />}
+      {isMe ? <MyProfileButton /> : <ProfileButton isFollowing={user.isFollowing} />}
     </div>
   );
 }

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -14,7 +14,11 @@ function UserProfile({ isMe, user }) {
         followerCount={user.followerCount}
         followingCount={user.followingCount}
       />
-      {isMe ? <MyProfileButton /> : <ProfileButton isFollowing={user.isFollowing} />}
+      {isMe ? (
+        <MyProfileButton />
+      ) : (
+        <ProfileButton isFollowing={user.isFollowing} />
+      )}
     </div>
   );
 }

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
+import UserProfile from "../components/organisms/UserProfile/UserProfile";
+
+// 원래는 계정 정보를 받아와야 하는데, 임시로 더미 정보를 넣어주었습니다.
+function ProfilePage() {
+  return (
+    <div>
+      <HeaderForm backButton={true} menuButton={true} />
+      {/* isMe=true이면 나의 프로필, 아니면 다른 사람의 프로필입니다. */}
+      <UserProfile isMe={false} />
+    </div>
+  );
+}
+
+export default ProfilePage;

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -5,7 +5,7 @@ import UserProfile from "../components/organisms/UserProfile/UserProfile";
 // 원래는 계정 정보를 받아와야 하는데, 임시로 더미 정보를 넣어주었습니다.
 function ProfilePage() {
   return (
-    <div>
+    <>
       <HeaderForm backButton={true} menuButton={true} />
       {/* isMe=true이면 나의 프로필, 아니면 다른 사람의 프로필입니다. */}
       {/* 나중에 현재 로그인된 accountname과 프로필의 accountname을 비교하면 될 거 같아요 */}
@@ -24,7 +24,7 @@ function ProfilePage() {
           followingCount: 128,
         }}
       />
-    </div>
+    </>
   );
 }
 

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -8,7 +8,22 @@ function ProfilePage() {
     <div>
       <HeaderForm backButton={true} menuButton={true} />
       {/* isMe=true이면 나의 프로필, 아니면 다른 사람의 프로필입니다. */}
-      <UserProfile isMe={false} />
+      {/* 나중에 현재 로그인된 accountname과 프로필의 accountname을 비교하면 될 거 같아요 */}
+      <UserProfile
+        isMe={false}
+        user={{
+          _id: "1",
+          username: "애월읍 위니브 게임랜드",
+          accountname: "weniv_Gameland",
+          intro: "제주 최고의 게임랜드를 찾으시나요?",
+          image: "http://www.paullab.co.kr/images/weniv-binky.png",
+          isfollow: false,
+          following: [],
+          follower: [],
+          followerCount: 2950,
+          followingCount: 128,
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 작업내용
- #11 에서 프로필 부분을 올가니즘화하고, /profile 페이지를 생성했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- (다 머지하고 나서) /profile 들어가시면 헤더와 결합한 임시 프로필 페이지가 나옵니다. 밑에 판매중인 상품 목록과 게시글 목록을 추가하면 페이지 완성... 😂 
## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
