### PR TITLE
Feat: 판매 중인 상품 목록에 들어갈 상품 컴포넌트 및 css 구현

### DIFF
--- a/src/components/modules/Product/Product.jsx
+++ b/src/components/modules/Product/Product.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+import styles from "./product.module.css";
+
+function Product({ src, name, price }) {
+  return (
+    <div className={styles["wrapper-product"]}>
+      <ImageBox type="rounded_square" size="small" src={src} alt="" />
+      <span className={styles["product_name"]}>{name}</span>
+      <strong className={styles["product_price"]}>{price.toLocaleString("en-US")}원</strong>
+    </div>
+  );
+}
+
+export default Product;

--- a/src/components/modules/Product/product.module.css
+++ b/src/components/modules/Product/product.module.css
@@ -1,0 +1,20 @@
+.wrapper-product {
+  max-width: 140px;
+}
+
+.product_name {
+  display: block;
+  margin: 6px 0 4px;
+  font-size: 1.4rem;
+  line-height: 18px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.product_price {
+  font-weight: 700;
+  font-size: 1.2rem;
+  line-height: 15px;
+  color: var(--main-color);
+}


### PR DESCRIPTION
## 작업내용
- #11 의 판매 중인 상품 목록 부분에 들어갈 상품 컴포넌트를 구현했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 상품 제목이 길어지면 말줄임표로 생략되게 하였습니다.
- 가격은 `toLocaleString("en-US")` 함수를 이용하여 `,`로 분리되게 하였습니다.
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?