### PR TITLE
판매 중인 상품 리스트 컴포넌트 및 css 구현

### DIFF
--- a/src/components/organisms/ProductList/ProductList.jsx
+++ b/src/components/organisms/ProductList/ProductList.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import Product from "../../modules/Product/Product";
+import styles from "./productList.module.css";
+
+function ProductList({ products }) {
+  return (
+    <div className={styles["wrapper-products"]}>
+      <h2 className={styles["title"]}>판매 중인 상품</h2>
+      <ul className={styles["list-product"]}>
+        {products.map((product, index) => {
+          return (
+            <li key={index}>
+              <Product
+                src={product.src}
+                name={product.name}
+                price={product.price}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export default ProductList;

--- a/src/components/organisms/ProductList/productList.module.css
+++ b/src/components/organisms/ProductList/productList.module.css
@@ -1,0 +1,22 @@
+.wrapper-products {
+  box-sizing: border-box;
+  padding: 20px;
+}
+
+.title {
+  margin-bottom: 16px;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 20px;
+}
+
+.list-product {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 10px;
+}
+
+


### PR DESCRIPTION
## 작업내용
- #11 에서 사용자 프로필 밑에 있는 **판매중인 상품** 부분의 리스트를 컴포넌트화했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 상품의 수가 많아지면 x축만 자동으로 스크롤이 생기도록 했습니다. (`overflow-x: auto;`)
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
