### PR TITLE
Feat: 상품 업로드 페이지 UI 완성

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import LoginPage from "./pages/LoginPage/LoginPage";
 import JoinPage from "./pages/JoinPage";
 import AddProductPage from "./pages/AddProductPage";
 import ProfilePage from "./pages/ProfilePage";
+import UploadPage from "./pages/UploadPage/UploadPage";
 import "./reset.css";
 import "./global.css";
 
@@ -23,6 +24,7 @@ function App() {
           path="/profile/following"
           element={<h1>팔로잉 목록 페이지입니다.</h1>}
         />
+        <Route path="/post" element={<UploadPage />}></Route>
       </Routes>
     </div>
   );

--- a/src/assets/x.svg
+++ b/src/assets/x.svg
@@ -1,0 +1,29 @@
+<svg width="22" height="25" viewBox="0 0 22 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_2_1177)">
+<g filter="url(#filter1_d_2_1177)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.3536 6.35355C16.5488 6.15829 16.5488 5.84171 16.3536 5.64645C16.1583 5.45118 15.8417 5.45118 15.6464 5.64645L11 10.2929L6.35355 5.64645C6.15829 5.45118 5.84171 5.45118 5.64645 5.64645C5.45118 5.84171 5.45118 6.15829 5.64645 6.35355L10.2929 11L5.64645 15.6464C5.45118 15.8417 5.45118 16.1583 5.64645 16.3536C5.84171 16.5488 6.15829 16.5488 6.35355 16.3536L11 11.7071L15.6464 16.3536C15.8417 16.5488 16.1583 16.5488 16.3536 16.3536C16.5488 16.1583 16.5488 15.8417 16.3536 15.6464L11.7071 11L16.3536 6.35355Z" fill="white"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_2_1177" x="-4" y="0" width="30" height="30" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2_1177"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2_1177" result="shape"/>
+</filter>
+<filter id="filter1_d_2_1177" x="3.5" y="3.5" width="15" height="15" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2_1177"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2_1177" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/atoms/IconButton/iconButton.module.css
+++ b/src/components/atoms/IconButton/iconButton.module.css
@@ -20,6 +20,10 @@
   background-image: url(../../../assets/icon-more-vertical.svg);
 }
 
+.close {
+  background-image: url(../../../assets/x.svg);
+}
+
 .message {
   background-image: url(../../../assets/icon-message-circle.svg);
   width: 34px;

--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -73,7 +73,7 @@
 
 /* 게시글에서 사용될 이미지입니다. */
 .rounded_square.medium_large {
-  width: 100%;
+  max-width: 400px;
 }
 
 /* 상품 등록 페이지에서 사용될 이미지입니다. */

--- a/src/components/atoms/ImageInputButton/ImageInputButton.jsx
+++ b/src/components/atoms/ImageInputButton/ImageInputButton.jsx
@@ -1,6 +1,8 @@
+import { useRef } from "react";
 import styles from "./imageInputButton.module.css";
 
-function ImageInputButton({ selectFile, saveImage, color, size }) {
+function ImageInputButton({ saveImage, color, size, multiple }) {
+  const selectFile = useRef("");
   function openFile() {
     selectFile.current.click();
   }
@@ -12,6 +14,7 @@ function ImageInputButton({ selectFile, saveImage, color, size }) {
         onChange={saveImage}
         ref={selectFile}
         className={styles["file-input"]}
+        multiple={multiple}
       />
       <button
         type="button"

--- a/src/components/modules/ImageInputForm/ImageInputForm.jsx
+++ b/src/components/modules/ImageInputForm/ImageInputForm.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import ImageBox from "../../atoms/ImageBox/ImageBox";
 import ImageInputButton from "../../atoms/ImageInputButton/ImageInputButton";
 import styles from "./imageInputForm.module.css";
@@ -6,7 +6,6 @@ import styles from "./imageInputForm.module.css";
 function ImageInputForm({ a11y, boxType, boxSize, buttonColor }) {
   // 상위 컴포넌트로 이동 필요
   const [image, setImage] = useState("");
-  const selectFile = useRef("");
   function saveImage(event) {
     setImage(URL.createObjectURL(event.target.files[0]));
   }
@@ -15,7 +14,6 @@ function ImageInputForm({ a11y, boxType, boxSize, buttonColor }) {
       {a11y && <p className="a11y-hidden">{a11y}</p>}
       <ImageBox src={image} type={boxType} size={boxSize} />
       <ImageInputButton
-        selectFile={selectFile}
         saveImage={saveImage}
         color={buttonColor}
         boxType={boxType}

--- a/src/components/modules/PostImage/PostImage.jsx
+++ b/src/components/modules/PostImage/PostImage.jsx
@@ -1,0 +1,18 @@
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+import IconButton from "../../atoms/IconButton/IconButton";
+import styles from "./postImage.module.css";
+
+function PostImage({ size, item, handleDeleteBtn }) {
+  return (
+    <div className={`${styles["wrapper-image"]} ${styles[size]}`}>
+      <ImageBox src={item.src} type="rounded_square" size={size} />
+      <IconButton
+        type="close"
+        text="이미지 취소"
+        onClick={() => handleDeleteBtn(item.key)}
+      />
+    </div>
+  );
+}
+
+export default PostImage;

--- a/src/components/modules/PostImage/postImage.module.css
+++ b/src/components/modules/PostImage/postImage.module.css
@@ -1,0 +1,17 @@
+.wrapper-image {
+  position: relative;
+}
+
+.wrapper-image > button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+}
+
+.medium_large {
+  max-width: 400px;
+}
+
+.medium_small {
+  width: 168px;
+}

--- a/src/components/organisms/PostForm/PostForm.jsx
+++ b/src/components/organisms/PostForm/PostForm.jsx
@@ -1,0 +1,33 @@
+import PostImage from "../../modules/PostImage/PostImage";
+import PostText from "../../modules/PostText/PostText";
+import styles from "./postForm.module.css";
+function PostForm({ images, handleDeleteBtn }) {
+  return (
+    <div className={styles["form-post"]}>
+      <PostText />
+      {images.length === 1 ? (
+        <PostImage
+          size="medium_large"
+          item={images[0]}
+          handleDeleteBtn={handleDeleteBtn}
+        />
+      ) : (
+        <ul className={styles["list"]}>
+          {images.map((item) => {
+            return (
+              <li key={item.key}>
+                <PostImage
+                  size="medium_small"
+                  item={item}
+                  handleDeleteBtn={handleDeleteBtn}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default PostForm;

--- a/src/components/organisms/PostForm/postForm.module.css
+++ b/src/components/organisms/PostForm/postForm.module.css
@@ -1,0 +1,11 @@
+.form-post > div:nth-child(2),
+.form-post > ul {
+  margin-left: 54px;
+}
+
+.list {
+  display: flex;
+  gap: 8px;
+  overflow-y: hidden;
+  overflow-x: auto;
+}

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
+import ImageInputButton from "../../components/atoms/ImageInputButton/ImageInputButton";
+import PostForm from "../../components/organisms/PostForm/PostForm";
+import styles from "./uploadPage.module.css";
+
+function UploadPage() {
+  const [images, setImages] = useState([]);
+  function saveImage(event) {
+    let copyImages = [...images];
+    for (let i = 0; i < event.target.files.length; i++) {
+      const image = {
+        key: Date.now() + i,
+        src: URL.createObjectURL(event.target.files[i]),
+      };
+      copyImages.unshift(image);
+    }
+    setImages(copyImages);
+  }
+  function handleDeleteBtn(key) {
+    const imagesArr = images.filter((item) => item.key !== key);
+    setImages(imagesArr);
+  }
+  return (
+    <div className={styles["wrapper-page"]}>
+      <HeaderForm backButton={true} button="업로드" />
+      <PostForm images={images} handleDeleteBtn={handleDeleteBtn} />
+      <ImageInputButton saveImage={saveImage} size="medium" multiple={true} />
+    </div>
+  );
+}
+
+export default UploadPage;

--- a/src/pages/UploadPage/uploadPage.module.css
+++ b/src/pages/UploadPage/uploadPage.module.css
@@ -1,0 +1,14 @@
+.wrapper-page {
+  height: 100vh;
+  position: relative;
+}
+
+.wrapper-page > div:nth-child(2) {
+  padding: 20px 16px 16px;
+}
+
+.wrapper-page > div:last-child {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+}


### PR DESCRIPTION
## 작업내용
- #10 
 UI 작업을 완료하였습니다. 
### 작업 이미지 
1) 상품 이미지가 하나일때 - 큰 이미지
![image](https://user-images.githubusercontent.com/68495264/178525325-1838ca85-11bd-4e55-a337-731066af8d1a.png)
2) 상품 이미지가 여러개일때 - 리스트로 정렬
![image](https://user-images.githubusercontent.com/68495264/178525508-2832cf5c-a752-459b-a316-a9a17bcfc2b1.png)

## 중점적으로 봐주었으면 하는 부분
- 이미지 추가 버튼, 이미지 삭제 버튼 기능도 작동합니다😆
- /post 로 이동하셔서 확인해보시고 이상한 부분 지적해주세요!
- 텍스트 길이 제한, 이미지 추가 개수 제한은 이후 추가해야할 사항입니다!

## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
