### PR TITLE
Feat: 포스트 페이지, 채팅 페이지 하단 댓글, 채팅 입력 모듈 컴포넌트 UI 생성

### DIFF
--- a/src/components/modules/MessageInput/MessageInput.jsx
+++ b/src/components/modules/MessageInput/MessageInput.jsx
@@ -1,0 +1,40 @@
+import { useState, useRef, useEffect } from "react";
+import styles from "./messageInput.module.css";
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+import ImageInputButton from "../../atoms/ImageInputButton/ImageInputButton";
+
+function Comment({ type, src, title, placeholder, buttonText }) {
+  const [text, setText] = useState("");
+  const inputRef = useRef();
+  //mount 되면 input focus
+  useEffect(() => {
+    inputRef.current.focus();
+  }, []);
+  function handleTextInput(event) {
+    setText(event.target.value);
+  }
+  return (
+    <div className={styles["wrapper-comment"]}>
+      {type === "comment" && (
+        <ImageBox src={src} type="circle" size="small" alt="프로필 이미지" />
+      )}
+      {type === "message" && <ImageInputButton color="gray" size="medium" />}
+      <input
+        type="text"
+        ref={inputRef}
+        placeholder={placeholder}
+        title={title}
+        onChange={handleTextInput}
+        className={styles["comment-input"]}
+      />
+      <button
+        type="submit"
+        className={text ? styles["button-active"] : styles["button-disable"]}
+      >
+        {buttonText}
+      </button>
+    </div>
+  );
+}
+
+export default Comment;

--- a/src/components/modules/MessageInput/MessageInput.jsx
+++ b/src/components/modules/MessageInput/MessageInput.jsx
@@ -3,7 +3,7 @@ import styles from "./messageInput.module.css";
 import ImageBox from "../../atoms/ImageBox/ImageBox";
 import ImageInputButton from "../../atoms/ImageInputButton/ImageInputButton";
 
-function Comment({ type, src, title, placeholder, buttonText }) {
+function MessageInput({ type, src, title, placeholder, buttonText }) {
   const [text, setText] = useState("");
   const inputRef = useRef();
   //mount 되면 input focus
@@ -37,4 +37,4 @@ function Comment({ type, src, title, placeholder, buttonText }) {
   );
 }
 
-export default Comment;
+export default MessageInput;

--- a/src/components/modules/MessageInput/messageInput.module.css
+++ b/src/components/modules/MessageInput/messageInput.module.css
@@ -24,11 +24,11 @@
   border: none;
   font-size: 1.4rem;
   font-weight: 500;
-  cursor: pointer;
 }
 
 .button-active {
   color: var(--main-color);
+  cursor: pointer;
 }
 
 .button-disable {

--- a/src/components/modules/MessageInput/messageInput.module.css
+++ b/src/components/modules/MessageInput/messageInput.module.css
@@ -33,4 +33,5 @@
 
 .button-disable {
   color: var(--middlegray-color);
+  pointer-events: none;
 }

--- a/src/components/modules/MessageInput/messageInput.module.css
+++ b/src/components/modules/MessageInput/messageInput.module.css
@@ -1,0 +1,36 @@
+.wrapper-comment {
+  display: flex;
+  padding: 12.5px 16px 12px;
+  border-top: 1px solid var(--lightgray-color);
+}
+
+.wrapper-comment > div > button {
+  position: static;
+}
+
+.comment-input {
+  margin: 0 10px 0 13px;
+  padding: 0 5px;
+  flex-grow: 1;
+  border: none;
+  font-size: 1.4rem;
+  outline: none;
+  outline-color: var(--main-color);
+}
+
+.wrapper-comment > button {
+  background-color: transparent;
+  outline: none;
+  border: none;
+  font-size: 1.4rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.button-active {
+  color: var(--main-color);
+}
+
+.button-disable {
+  color: var(--middlegray-color);
+}


### PR DESCRIPTION
## 작업내용
- #9 
1) 입력전 - 버튼 비활성화
![image](https://user-images.githubusercontent.com/68495264/178654728-280d00d4-3416-495d-8e18-5c0c4ddf4a97.png)
2) 입력 후 - 버튼 활성화 
![image](https://user-images.githubusercontent.com/68495264/178653468-a60bb5bd-f563-48fe-a0bd-d39b50b7db79.png)
```
<MessageInput
    type="comment"
    src=""
    title="댓글"
    placeholder="댓글 입력하기..."
    buttonText="게시"
  />
```
- #7 
![image](https://user-images.githubusercontent.com/68495264/178653484-e32ee4de-fd2f-4083-8fac-295135545174.png)
![image](https://user-images.githubusercontent.com/68495264/178653514-876b287c-6874-4ec1-b9bf-e680669beda8.png)
```
 <MessageInput
    type="message"
    title="메세지"
    placeholder="메세지 입력하기..."
    buttonText="전송"
  />
```

## 중점적으로 봐주었으면 하는 부분
- @hee1231 님!! 채팅 페이지에서도 텍스트 입력 하단 컴포넌트가 필요한 것 같아 같이 만들었습니다! 활용해주세요 :>
- 텍스트를 입력하면, 버튼이 활성화 됩니다. 
- 컴포넌트가 보여질때 바로 input에 focus됩니다. 

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
