### PR TITLE
Feat: 팔로워/팔로잉 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import ProfilePage from "./pages/ProfilePage";
 import UploadPage from "./pages/UploadPage/UploadPage";
 import "./reset.css";
 import "./global.css";
+import FollowerPage from "./pages/FollowerPage";
+import FollowingPage from "./pages/FollowingPage.jsx";
 
 function App() {
   return (
@@ -17,12 +19,12 @@ function App() {
         <Route path="/product" element={<AddProductPage />} />
         <Route path="/profile/:accountname" element={<ProfilePage />} />
         <Route
-          path="/profile/follower"
-          element={<h1>팔로워 목록 페이지입니다.</h1>}
+          path="/profile/:accountname/follower"
+          element={<FollowerPage />}
         />
         <Route
-          path="/profile/following"
-          element={<h1>팔로잉 목록 페이지입니다.</h1>}
+          path="/profile/:accountname/following"
+          element={<FollowingPage />}
         />
         <Route path="/post" element={<UploadPage />}></Route>
       </Routes>

--- a/src/components/atoms/NumberFollow/NumberFollow.jsx
+++ b/src/components/atoms/NumberFollow/NumberFollow.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import styles from "./numberFollow.module.css";
 
 function NumberFollow({ number, isFollower }) {
@@ -8,9 +8,9 @@ function NumberFollow({ number, isFollower }) {
   isFollower ? null : classList.push("following");
   const CLASS_LIST = classList.map((item) => styles[item]).join(" ");
 
-  // 나중에 :accountname 추가해야 합니다.
-  const followerURL = "/profile/follower";
-  const followingURL = "/profile/following";
+  let { accountname } = useParams();
+  const followerURL = `/profile/${accountname}/follower`;
+  const followingURL = `/profile/${accountname}/following`;
 
   return (
     <Link

--- a/src/components/modules/HeaderForm/headerForm.module.css
+++ b/src/components/modules/HeaderForm/headerForm.module.css
@@ -7,6 +7,7 @@
 }
 
 .large {
+  padding-left: 8px;
   font-size: 1.8rem;
 }
 

--- a/src/components/modules/Product/Product.jsx
+++ b/src/components/modules/Product/Product.jsx
@@ -1,13 +1,18 @@
 import React from "react";
+// import { Link } from "react-router-dom";
 import ImageBox from "../../atoms/ImageBox/ImageBox";
 import styles from "./product.module.css";
 
-function Product({ src, name, price }) {
+function Product({ link, itemImage, itemName, price }) {
   return (
     <div className={styles["wrapper-product"]}>
-      <ImageBox type="rounded_square" size="small" src={src} alt="" />
-      <span className={styles["product_name"]}>{name}</span>
-      <strong className={styles["product_price"]}>{price.toLocaleString("en-US")}원</strong>
+      <a href={link}>
+        <ImageBox type="rounded_square" size="small" src={itemImage} alt="" />
+        <span className={styles["product_name"]}>{itemName}</span>
+        <strong className={styles["product_price"]}>
+          {price.toLocaleString("en-US")}원
+        </strong>
+      </a>
     </div>
   );
 }

--- a/src/components/modules/UserFollow/UserFollow.jsx
+++ b/src/components/modules/UserFollow/UserFollow.jsx
@@ -4,13 +4,24 @@ import UserNameIntroduce from "../../atoms/UserNameIntroduce/UserNameIntroduce";
 import Button from "../../atoms/Button/Button";
 import styles from "./userFollow.module.css";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
-function UserFollow({ src, userName, userIntroduce }) {
+function UserFollow({ user }) {
   const [isFollowing, setIsFollowing] = useState(false);
   return (
-    <div className={styles["follow-wrapper"]}>
-      <ImageBox src={src} type="circle" size="medium" alt="프로필 이미지" />
-      <UserNameIntroduce userName={userName} userIntroduce={userIntroduce} />
+    <div className={styles["wrapper-follow"]}>
+      <Link to={`/profile/${user.accountname}`} className={styles["wrapper-link"]}>
+        <ImageBox
+          src={user.image}
+          type="circle"
+          size="medium"
+          alt="프로필 이미지"
+        />
+        <UserNameIntroduce
+          userName={user.username}
+          userIntroduce={user.intro}
+        />
+      </Link>
       <Button
         size="small"
         label={isFollowing ? "취소" : "팔로우"}

--- a/src/components/modules/UserFollow/userFollow.module.css
+++ b/src/components/modules/UserFollow/userFollow.module.css
@@ -1,4 +1,4 @@
-.follow-wrapper {
+.wrapper-follow {
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -6,12 +6,17 @@
   margin: 0px auto;
 }
 
-.follow-wrapper > div:nth-child(2) {
+.wrapper-link{
+  display: flex;
+  justify-content: flex-start;
+}
+
+.wrapper-link > div:nth-child(2) {
   max-width: 240px;
   margin: 5px 0 6px 12px;
 }
 
-.follow-wrapper > button {
+.wrapper-follow > button {
   width: 56px;
   justify-self: end;
   margin-left: auto;

--- a/src/components/organisms/FollowList/FollowList.jsx
+++ b/src/components/organisms/FollowList/FollowList.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import UserFollow from "../../modules/UserFollow/UserFollow";
+import styles from "./followList.module.css";
+
+function FollowList({ list }) {
+  console.log(list);
+  return list.length > 0 ? (
+    <ul className={styles["list-follow"]}>
+      {list.map((user) => {
+        return (
+          <li key={user._id}>
+            <UserFollow user={user} />
+          </li>
+        );
+      })}
+    </ul>
+  ) : (
+    <div className={styles["wrapper-message"]}>
+      <p className={`${styles["emoji"]}`}>😥</p>
+      <p>아직 아무도 없어요.</p>
+    </div>
+  );
+}
+
+export default FollowList;

--- a/src/components/organisms/FollowList/followList.module.css
+++ b/src/components/organisms/FollowList/followList.module.css
@@ -1,0 +1,19 @@
+.list-follow {
+  margin: 24px auto;
+}
+
+.list-follow li {
+  margin: 16px auto;
+}
+
+.wrapper-message {
+  margin: 50px auto;
+  text-align: center;
+  font-size: 2rem;
+  color: var(--middlegray-color);
+}
+
+.emoji {
+  margin: 20px auto;
+  font-size: 6rem;
+}

--- a/src/components/organisms/ProductList/ProductList.jsx
+++ b/src/components/organisms/ProductList/ProductList.jsx
@@ -6,19 +6,24 @@ function ProductList({ products }) {
   return (
     <div className={styles["wrapper-products"]}>
       <h2 className={styles["title"]}>판매 중인 상품</h2>
-      <ul className={styles["list-product"]}>
-        {products.map((product, index) => {
-          return (
-            <li key={index}>
-              <Product
-                src={product.src}
-                name={product.name}
-                price={product.price}
-              />
-            </li>
-          );
-        })}
-      </ul>
+      {products.data > 0 ? (
+        <ul className={styles["list-product"]}>
+          {products.product.map((product, index) => {
+            return (
+              <li key={index}>
+                <Product
+                  link={product.link}
+                  itemImage={product.itemImage}
+                  itemName={product.itemName}
+                  price={product.price}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className={styles["message"]}>판매 중인 상품이 없어요.</p>
+      )}
     </div>
   );
 }

--- a/src/components/organisms/ProductList/productList.module.css
+++ b/src/components/organisms/ProductList/productList.module.css
@@ -19,4 +19,10 @@
   padding-bottom: 10px;
 }
 
-
+.message {
+  height: 160px;
+  line-height: 160px;
+  text-align: center;
+  font-size: 2rem;
+  color: var(--middlegray-color);
+}

--- a/src/pages/FollowerPage.jsx
+++ b/src/pages/FollowerPage.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
+import FollowList from "../components/organisms/FollowList/FollowList";
+
+function FollowerPage() {
+  // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.
+  let { accountname } = useParams();
+  const [followers, setFollowers] = useState([]);
+
+  useEffect(() => {
+    const baseURL = "https://mandarin.api.weniv.co.kr";
+    const token = window.localStorage.getItem("token");
+
+    async function getFollowers() {
+      try {
+        const data = await fetch(baseURL + `/profile/${accountname}/follower`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        });
+        const result = await data.json();
+        setFollowers(result);
+      } catch (error) {
+        console.log(error.message);
+      }
+    }
+    getFollowers();
+  }, [accountname]);
+
+  return (
+    <>
+      <h1 className="a11y-hidden">팔로워 페이지</h1>
+      <HeaderForm
+        backButton={true}
+        title="Followers"
+        titleSize="large"
+        menuButton={false}
+      />
+      {followers && <FollowList list={followers} />}
+    </>
+  );
+}
+
+export default FollowerPage;

--- a/src/pages/FollowingPage.jsx
+++ b/src/pages/FollowingPage.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
+import FollowList from "../components/organisms/FollowList/FollowList";
+
+function FollowingPage() {
+  // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.
+  let { accountname } = useParams();
+  const [followings, setFollowings] = useState([]);
+
+  useEffect(() => {
+    const baseURL = "https://mandarin.api.weniv.co.kr";
+    const token = window.localStorage.getItem("token");
+
+    async function getFollowings() {
+      try {
+        const data = await fetch(
+          baseURL + `/profile/${accountname}/following`,
+          {
+            method: "GET",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-type": "application/json",
+            },
+          }
+        );
+        const result = await data.json();
+        setFollowings(result);
+      } catch (error) {
+        console.log(error.message);
+      }
+    }
+    getFollowings();
+  }, [accountname]);
+
+  return (
+    <>
+      <h1 className="a11y-hidden">팔로잉 페이지</h1>
+      <HeaderForm
+        backButton={true}
+        title="Followings"
+        titleSize="large"
+        menuButton={false}
+      />
+      {followings && <FollowList list={followings} />}
+    </>
+  );
+}
+
+export default FollowingPage;

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -89,7 +89,6 @@ function ProfilePage() {
   //   },
   // ];
 
-  console.log(products);
   return (
     <>
       <h1 className="a11y-hidden">프로필 페이지</h1>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -9,13 +9,15 @@ function ProfilePage() {
   // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.
   let { accountname } = useParams();
   const [profile, setProfile] = useState({});
+  const [products, setProducts] = useState([]);
+  // baseurl과 토큰 받아오는 코드는 나중에 상위로 옮겨서 전역으로 관리하면 좋을 거 같아요
+  const baseURL = "https://mandarin.api.weniv.co.kr";
+  const token = window.localStorage.getItem("token");
 
   useEffect(() => {
-    // baseurl과 토큰 받아오는 코드는 나중에 상위로 옮겨서 전역으로 관리하면 좋을 거 같아요
-    const baseURL = "https://mandarin.api.weniv.co.kr";
-    const token = window.localStorage.getItem("token");
-
     // 호준님 말씀대로 api는 메소드별로 따로 함수화해서 관리해도 좋을 것 같습니다
+
+    // 사용자의 프로필 정보를 받아오는 함수입니다.
     async function getProfile() {
       try {
         const data = await fetch(baseURL + `/profile/${accountname}`, {
@@ -31,46 +33,63 @@ function ProfilePage() {
         console.log(error.message);
       }
     }
+
+    // 사용자의 상품 리스트를 받아오는 함수입니다.
+    async function getProducts() {
+      try {
+        const data = await fetch(baseURL + `/product/${accountname}`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-type": "application/json",
+          },
+        });
+        const result = await data.json();
+        console.log(result);
+        setProducts(result);
+      } catch (error) {
+        console.log(error.message);
+      }
+    }
     getProfile();
+    getProducts();
   }, [accountname]);
 
-  // 프로필 내용 확인 코드입니다. 추후에 삭제할게요
-  // console.log("current profile: " + JSON.stringify(profile));
+  // 더미 데이터
+  // const productArray = [
+  //   {
+  //     src: "https://img.insight.co.kr/static/2020/03/15/700/c5imbg6083e96xgj9g6f.jpg",
+  //     name: "스위치 동숲에디션 상태굿",
+  //     price: 350000,
+  //   },
+  //   {
+  //     src: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Sega-Mega-Drive-JP-Mk1-Console-Set.jpg/1024px-Sega-Mega-Drive-JP-Mk1-Console-Set.jpg",
+  //     name: "메가드라이브 s급 중고 팝니다",
+  //     price: 120000,
+  //   },
+  //   {
+  //     src: "https://www.nintendo.co.kr/hardware/modal/img/lineup/img-package--oled_white.jpg",
+  //     name: "스위치 올레드 미개봉",
+  //     price: 415000,
+  //   },
+  //   {
+  //     src: "https://blog.kakaocdn.net/dn/lJFMB/btqPaU5VmRz/yikdl5hStOQlkBM7PkfkK0/img.jpg",
+  //     name: "엑박 4세대 패드 블랙 팔아요",
+  //     price: 50000,
+  //   },
+  //   {
+  //     src: "https://image.yes24.com/usedshop/2020/1211/_/540cd528-468a-462f-8084-2314c0c8a6ba_XL.JPG",
+  //     name: "롤코타1 cd 팔아요",
+  //     price: 10000,
+  //   },
+  //   {
+  //     src: "https://mblogthumb-phinf.pstatic.net/MjAxODEwMzFfMjQ4/MDAxNTQwOTcxODcyOTEw.hNRinR5oQ0IF-Clb77oJa8lCbNog6yhf2Hisstqd_0Mg.GwLjuu2I-Fe5P-13duns4KdnpwZi7CT8EoSw7yzuGyYg.JPEG.aprileehj/image_2064034831540971847056.jpg?type=w800",
+  //     name: "플스4 레데리2 팝니다",
+  //     price: 20000,
+  //   },
+  // ];
 
-  // GET으로 받아 오는 유저 정보에 판매중인 상품 관련 정보가 없어서 우선 더미 데이터를 유지하겠습니다
-  const productArray = [
-    {
-      src: "https://img.insight.co.kr/static/2020/03/15/700/c5imbg6083e96xgj9g6f.jpg",
-      name: "스위치 동숲에디션 상태굿",
-      price: 350000,
-    },
-    {
-      src: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Sega-Mega-Drive-JP-Mk1-Console-Set.jpg/1024px-Sega-Mega-Drive-JP-Mk1-Console-Set.jpg",
-      name: "메가드라이브 s급 중고 팝니다",
-      price: 120000,
-    },
-    {
-      src: "https://www.nintendo.co.kr/hardware/modal/img/lineup/img-package--oled_white.jpg",
-      name: "스위치 올레드 미개봉",
-      price: 415000,
-    },
-    {
-      src: "https://blog.kakaocdn.net/dn/lJFMB/btqPaU5VmRz/yikdl5hStOQlkBM7PkfkK0/img.jpg",
-      name: "엑박 4세대 패드 블랙 팔아요",
-      price: 50000,
-    },
-    {
-      src: "https://image.yes24.com/usedshop/2020/1211/_/540cd528-468a-462f-8084-2314c0c8a6ba_XL.JPG",
-      name: "롤코타1 cd 팔아요",
-      price: 10000,
-    },
-    {
-      src: "https://mblogthumb-phinf.pstatic.net/MjAxODEwMzFfMjQ4/MDAxNTQwOTcxODcyOTEw.hNRinR5oQ0IF-Clb77oJa8lCbNog6yhf2Hisstqd_0Mg.GwLjuu2I-Fe5P-13duns4KdnpwZi7CT8EoSw7yzuGyYg.JPEG.aprileehj/image_2064034831540971847056.jpg?type=w800",
-      name: "플스4 레데리2 팝니다",
-      price: 20000,
-    },
-  ];
-
+  console.log(products);
   return (
     <>
       <h1 className="a11y-hidden">프로필 페이지</h1>
@@ -78,7 +97,7 @@ function ProfilePage() {
       {/* isMe=true이면 나의 프로필, 아니면 다른 사람의 프로필입니다. */}
       {/* 나중에 현재 로그인된 accountname과 프로필의 accountname을 비교하면 될 거 같아요 */}
       <UserProfile isMe={true} userProfile={profile} />
-      <ProductList products={productArray} />
+      <ProductList products={products} />
     </>
   );
 }


### PR DESCRIPTION
## 작업내용
- #13 의 마크업을 완료했습니다. (팔로우/취소 기능 구현은 아직입니다..)
- #11 의 판매중인 상품 목록을 사용자가 판매하는 목록으로 가져왔습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 상품 목록과 팔로워/팔로잉 목록이 비어 있으면 비어 있다는 메시지를 출력하게 했습니다.

![image](https://user-images.githubusercontent.com/79434205/178926976-1e083ef6-3a60-4ab5-b143-374353d47afb.png)

![image](https://user-images.githubusercontent.com/79434205/178927055-81509e5f-dc62-400a-b0ba-ecd139d9913d.png)

- 상품 컴포넌트에 링크를 달아주긴 했는데, 상품 게시글은 상세 페이지가 따로 없어서 사람들이 링크를 유튜브나 네이버 같은 걸로 적어 놓았더라고요. 아예 링크를 뺄까 생각중입니다.
- 팔로워/팔로잉 페이지의 이미지나 이름을 누르면 그 사람의 페이지로 이동하게 했습니다.
- 팔로워/팔로잉 목록이 로딩 중일 때, 비어 있을 때 나오는 메시지가 출력됐다가 사라집니다. 로딩 중인 상태를 체크하는 기능을 추가하겠습니다.
- 팔로우/취소 기능은 아직입니다. 빨리 구현하겠습니다. 😅 
## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
