### PR TITLE
Fix: icon-more-vertical-small.svg 파일 내 오타가 있어 생긴 버그 수정

### DIFF
--- a/src/assets/icon-more-vertical-small.svg
+++ b/src/assets/icon-more-vertical-small.svg
@@ -1,0 +1,5 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="8.25" y="3" width="1.5" height="1.5" fill="#C4C4C4" stroke="#C4C4C4"/>
+<rect x="8.25" y="8.25" width="1.5" height="1.5" fill="#C4C4C4" stroke="#C4C4C4"/>
+<rect x="8.25" y="13.5" width="1.5" height="1.5" fill="#C4C4C4" stroke="#C4C4C4"/>
+</svg>


### PR DESCRIPTION
## 작업내용
세로 더보기 메뉴의 svg 파일에 오타가 있어 수정하였습니다.


## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
