### PR TITLE
Feat: Upload page 텍스트, 이미지 업로드 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,10 @@ function App() {
           element={<FollowingPage />}
         />
         <Route path="profile/edit" element={<ProfileEditPage />} />
-        <Route path="/post" element={<UploadPage />} />
+        <Route
+          path="/post"
+          element={<UploadPage accountname={accountname} />}
+        />
       </Routes>
     </div>
   );

--- a/src/components/atoms/TextArea/TextArea.jsx
+++ b/src/components/atoms/TextArea/TextArea.jsx
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useEffect } from "react";
 import styles from "./textArea.module.css";
 
-function TextArea({ label }) {
+function TextArea({ label, handleText }) {
   const textRef = useRef();
   //textarea 높이 조절
   const textAreaResize = useCallback(() => {
@@ -25,7 +25,10 @@ function TextArea({ label }) {
         ref={textRef}
         placeholder="게시글 입력하기.."
         className={styles["input-text"]}
-        onChange={textAreaResize}
+        onChange={(event) => {
+          textAreaResize();
+          handleText(event);
+        }}
       ></textarea>
     </>
   );

--- a/src/components/modules/UploadText/UploadText.jsx
+++ b/src/components/modules/UploadText/UploadText.jsx
@@ -2,11 +2,11 @@ import ImageBox from "../../atoms/ImageBox/ImageBox";
 import TextArea from "../../atoms/TextArea/TextArea";
 import styles from "./uploadText.module.css";
 
-function UploadText() {
+function UploadText({ handleText }) {
   return (
     <div className={styles["wrapper-post"]}>
       <ImageBox src="" type="circle" size="medium_small" alt="프로필 이미지" />
-      <TextArea label="게시글 입력" />
+      <TextArea label="게시글 입력" handleText={handleText} />
     </div>
   );
 }

--- a/src/components/organisms/UploadForm/UploadForm.jsx
+++ b/src/components/organisms/UploadForm/UploadForm.jsx
@@ -1,10 +1,10 @@
 import UploadText from "../../modules/UploadText/UploadText";
 import UploadImage from "../../modules/UploadImage/UploadImage";
 import styles from "./uploadForm.module.css";
-function UploadForm({ images, handleDeleteBtn }) {
+function UploadForm({ images, handleText, handleDeleteBtn }) {
   return (
     <div className={styles["form-post"]}>
-      <UploadText />
+      <UploadText handleText={handleText} />
       {images.length === 1 ? (
         <UploadImage
           size="medium_large"

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -1,30 +1,146 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import imageCompression from "browser-image-compression";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import ImageInputButton from "../../components/atoms/ImageInputButton/ImageInputButton";
 import UploadForm from "../../components/organisms/UploadForm/UploadForm";
 import styles from "./uploadPage.module.css";
 
-function UploadPage() {
+function UploadPage({ accountname }) {
+  const navigate = useNavigate();
+  const [text, setText] = useState("");
   const [images, setImages] = useState([]);
-  function saveImage(event) {
-    let copyImages = [...images];
-    for (let i = 0; i < event.target.files.length; i++) {
-      const image = {
-        key: Date.now() + i,
-        src: URL.createObjectURL(event.target.files[i]),
-      };
-      copyImages.unshift(image);
-    }
-    setImages(copyImages);
+  const baseURL = "https://mandarin.api.weniv.co.kr";
+  const token = window.localStorage.getItem("token");
+
+  //텍스트 처리
+  function handleText(event) {
+    setText(event.target.value);
   }
+  //이미지 삭제 버튼
   function handleDeleteBtn(key) {
     const imagesArr = images.filter((item) => item.key !== key);
     setImages(imagesArr);
   }
+  //이미지 업로드 제한 & 프리뷰
+  async function saveImage(event) {
+    const files = event.target.files;
+    if (!files) return;
+    if (images.length + files.length > 3) {
+      alert("이미지는 3개까지 업로드 가능합니다.");
+      return;
+    }
+    const copyImages = [...images];
+    for (let i = 0; i < files.length; i++) {
+      const image = {
+        key: Date.now() + i,
+        src: URL.createObjectURL(files[i]),
+        data: files[i],
+      };
+      if (files.length === 1) {
+        copyImages.unshift(image);
+      } else {
+        copyImages.push(image);
+      }
+    }
+    setImages(copyImages);
+  }
+  //이미지 리사이즈
+  async function handleImageSize(file) {
+    const options = {
+      maxSizeMB: 1,
+      maxWidthOrHeight: 500,
+    };
+    try {
+      const blobFile = await imageCompression(file, options);
+      const newFile = new File([blobFile], `${blobFile.name}`, {
+        type: blobFile.type,
+      });
+      return newFile;
+    } catch (error) {
+      console.log(error);
+    }
+  }
+  //여러장 이미지 업로드
+  async function multipleImageUpload(files) {
+    let fileNames = [];
+    const imageReqPath = "/image/uploadfile";
+    try {
+      for (let file of files) {
+        const formData = new FormData();
+        formData.append("image", file);
+        const res = await fetch(baseURL + imageReqPath, {
+          method: "POST",
+          body: formData,
+        });
+        const json = await res.json();
+        const filename = await json.filename;
+        fileNames.push(filename);
+      }
+      if (fileNames.length > 1) {
+        return fileNames.join(",");
+      } else {
+        return fileNames[0];
+      }
+    } catch (error) {
+      console.log(error.message);
+    }
+  }
+  async function handleuploadImages() {
+    const imageArr = [];
+    for (let file of images) {
+      imageArr.push(await handleImageSize(file.data));
+    }
+    return await multipleImageUpload(imageArr);
+  }
+  //데이터 업로드
+  async function uploadData(imageNames) {
+    const imageData = imageNames
+      .split(",")
+      .map((name) => baseURL + "/" + name)
+      .join(", ");
+    const data = {
+      post: {
+        content: text,
+        image: imageData,
+      },
+    };
+    try {
+      fetch(baseURL + "/post", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-type": "application/json",
+        },
+        body: JSON.stringify(data),
+      });
+    } catch (error) {
+      console.log(error.message);
+    }
+  }
+
+  //업로드 버튼
+  async function handleUploadButton() {
+    const imageNames = await handleuploadImages();
+    await uploadData(imageNames);
+    //메모리 누수 방지
+    images.forEach((file) => URL.revokeObjectURL(file.src));
+    navigate(`/profile/${accountname}`);
+  }
+
   return (
     <div className={styles["wrapper-page"]}>
-      <HeaderForm backButton={true} button="업로드" />
-      <UploadForm images={images} handleDeleteBtn={handleDeleteBtn} />
+      <HeaderForm
+        backButton={true}
+        button="업로드"
+        onClick={handleUploadButton}
+        active={text && images.length > 0 && true}
+      />
+      <UploadForm
+        images={images}
+        handleText={handleText}
+        handleDeleteBtn={handleDeleteBtn}
+      />
       <ImageInputButton saveImage={saveImage} size="medium" multiple={true} />
     </div>
   );


### PR DESCRIPTION
## 작업내용
- #10 
텍스트와 이미지 업로드 기능을 구현하였습니다. 
- 글 입력시 업로드 버튼 활성화 구현
- 버튼 클릭시 게시글 업로드 구현
- 업로드 버튼을 누르면 /profile/${accoutname} 으로 이동합니다. 
1) 텍스트 미 입력 - 업로드 버튼 비활성화
![image](https://user-images.githubusercontent.com/68495264/179393313-355c3f94-2eb4-42b0-9bac-2748663bd598.png)
2) 텍스트, 이미지 모두 입력 - 업로드 버튼 활성화
![image](https://user-images.githubusercontent.com/68495264/179393303-f633539f-448c-46c9-bb10-468910724b33.png)
3) post가 성공적으로 되었는지 확인
![image](https://user-images.githubusercontent.com/68495264/179393414-5b36d854-d665-49fc-a92d-bcc1f916fc67.png)


## 중점적으로 봐주었으면 하는 부분
- 이미지를 변경할때마다 서버에서 url을 받아와 보여주니 동작이 느려서, 
업로드 버튼을 클릭하면 이미지 url을 받아오고, 데이터를 전송하도록 변경했습니다. 
(상품업로드 페이지에서도 이처럼 수정하려고 합니다)

- 여러 이미지 업로드 api를 이용하여, 한꺼번에 여러 image file를 서버에 보냈더니 가끔 다른 image file이 같은 url을 갖고 돌아오는 오류가 있어 이미지를 하나씩 서버로 보내도록 하여 해결했습니다. (추후 멘토님께 여쭤보도록 하겠습니다..!)

- 프로필 이미지는 로그인 구현 후 app.jsx에서 profile데이터를 받아와 처리해야 할 것 같습니다. 

## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
