### PR TITLE
Feat: 로그인 기능 구현 및 accountname으로 로그인한 계정 판별

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,24 +5,19 @@ import AddProductPage from "./pages/AddProductPage";
 import ProfilePage from "./pages/ProfilePage";
 import ProfileEditPage from "./pages/ProfileEditPage";
 import UploadPage from "./pages/UploadPage/UploadPage";
-import "./reset.css";
-import "./global.css";
 import FollowerPage from "./pages/FollowerPage";
 import FollowingPage from "./pages/FollowingPage.jsx";
+import "./reset.css";
+import "./global.css";
 
 function App() {
-  //로그인 구현후 변경 필요
-  const accountname = "weniv_Gameland";
   return (
     <div className="max-width">
       <Routes>
         <Route path="/" element={<h1>메인 페이지입니다.</h1>} />
-        <Route path="/user/login" element={<LoginPage />} />
+        <Route path="/login" element={<LoginPage />} />
         <Route path="/user" element={<JoinPage />} />
-        <Route
-          path="/product"
-          element={<AddProductPage accountname={accountname} />}
-        />
+        <Route path="/product" element={<AddProductPage />} />
         <Route path="/profile/:accountname" element={<ProfilePage />} />
         <Route
           path="/profile/:accountname/follower"

--- a/src/components/atoms/InputBox/InputBox.jsx
+++ b/src/components/atoms/InputBox/InputBox.jsx
@@ -1,7 +1,16 @@
 import React from "react";
 import styles from "./inputBox.module.css";
 
-function InputBox({ id, type, name, placeholder, error, onChange, maxLength }) {
+function InputBox({
+  id,
+  type,
+  name,
+  placeholder,
+  error,
+  onChange,
+  maxLength,
+  innerRef,
+}) {
   const errorClass = error ? "error" : "";
   return (
     <div>
@@ -16,6 +25,7 @@ function InputBox({ id, type, name, placeholder, error, onChange, maxLength }) {
         className={[styles["input-login"], styles[errorClass]].join(" ")}
         onChange={onChange}
         maxLength={maxLength}
+        ref={innerRef}
       />
       {error && <small className={styles["text-error"]}>{error}</small>}
     </div>

--- a/src/components/modules/LoginForm/LoginForm.jsx
+++ b/src/components/modules/LoginForm/LoginForm.jsx
@@ -1,21 +1,109 @@
 import React from "react";
 import InputBox from "../../atoms/InputBox/InputBox";
 import Button from "../../atoms/Button/Button";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
 
 function LoginForm({ label }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const baseURL = "https://mandarin.api.weniv.co.kr";
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setEmailError();
+    setPasswordError();
+  }, [email, password]);
+  // 이메일과 비밀번호 둘 다 input이므로 한꺼번에 관리합니다.
+  function handleData(event) {
+    // input 타입이 "email" 이면 이메일 세팅
+    if (event.target.type === "email") {
+      setEmail(event.target.value);
+    }
+    // input 타입이 "password" 이면 비밀번호 세팅
+    else if (event.target.type === "password") {
+      setPassword(event.target.value);
+    }
+  }
+  async function login() {
+    try {
+      const reqBody = {
+        user: {
+          email: email,
+          password: password,
+        },
+      };
+
+      const data = await fetch(baseURL + "/user/login", {
+        method: "POST",
+        headers: {
+          "Content-type": "application/json",
+        },
+        body: JSON.stringify(reqBody),
+      });
+      const result = await data.json();
+      console.log(result);
+      const emailRegExp =
+        /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+      // 이메일 형식이 일치하지 않는 경우 (button type이 submit이 아니라서 여기에서 유효성을 검사합니다.)
+      if (!email.match(emailRegExp)) {
+        setEmailError("이메일 형식에 맞게 입력해 주세요.");
+      }
+      // 이메일, 비밀번호가 일치하지 않는 경우
+      else if (result.status === 422) {
+        setPasswordError(result.message);
+      }
+      // 이메일 란이 비어있는 경우
+      else if (!email) {
+        setEmailError("이메일을 입력해 주세요.");
+      }
+      // 비밀번호 란이 비어있는 경우
+      else if (!password) {
+        setPasswordError("비밀번호를 입력해 주세요.");
+      }
+      // 이메일, 비밀번호가 둘 다 빈 경우는 아예 버튼을 disabled 시켰기 때문에 따로 에러 메시지를 띄우지 않게 했습니다.
+      window.localStorage.removeItem("accountname");
+      window.localStorage.setItem("accountname", result.user.accountname);
+      // 로컬 스토리지에 남아 있는 토큰을 지우고 다시 토큰을 설정합니다.
+      // 로그아웃 기능이 따로 없는 거 같아서 우선은 로그인하면서 지워줍니다.
+      window.localStorage.removeItem("token");
+      window.localStorage.setItem("token", result.user.token);
+      navigate("/");
+    } catch (error) {
+      console.log(error.message);
+    }
+  }
+
   return (
-    <div>
-      <InputBox id="email" type="email" name="이메일" />
-      <InputBox id="password" type="password" name="비밀번호" />
+    <form>
+      <InputBox
+        id="email"
+        type="email"
+        name="이메일"
+        value={email}
+        onChange={handleData}
+        error={emailError}
+      />
+      <InputBox
+        id="password"
+        type="password"
+        name="비밀번호"
+        value={password}
+        onChange={handleData}
+        error={passwordError}
+      />
       <Button
         href={null}
         size="large"
         label={label}
-        active={false}
+        active={(email || password) && true}
         primary={true}
-        onClick={null}
+        onClick={login}
       />
-    </div>
+    </form>
   );
 }
 

--- a/src/components/modules/LoginForm/LoginForm.jsx
+++ b/src/components/modules/LoginForm/LoginForm.jsx
@@ -47,7 +47,7 @@ function LoginForm({ label }) {
       const result = await data.json();
       console.log(result);
       const emailRegExp =
-        /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+      /^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/i;
       // 이메일 란이 비어있는 경우
       if (!email) {
         setEmailError("이메일을 입력해 주세요.");

--- a/src/components/modules/LoginForm/LoginForm.jsx
+++ b/src/components/modules/LoginForm/LoginForm.jsx
@@ -48,22 +48,22 @@ function LoginForm({ label }) {
       console.log(result);
       const emailRegExp =
         /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-      // 이메일 형식이 일치하지 않는 경우 (button type이 submit이 아니라서 여기에서 유효성을 검사합니다.)
-      if (!email.match(emailRegExp)) {
+      // 이메일 란이 비어있는 경우
+      if (!email) {
+        setEmailError("이메일을 입력해 주세요.");
+      }
+      // 비밀번호 란이 비어있는 경우
+      else if (!password) {
+        setPasswordError("비밀번호를 입력해 주세요.");
+      } // 이메일 형식이 일치하지 않는 경우 (button type이 submit이 아니라서 여기에서 유효성을 검사합니다.)
+      else if (!email.match(emailRegExp)) {
         setEmailError("이메일 형식에 맞게 입력해 주세요.");
       }
       // 이메일, 비밀번호가 일치하지 않는 경우
       else if (result.status === 422) {
         setPasswordError(result.message);
       }
-      // 이메일 란이 비어있는 경우
-      else if (!email) {
-        setEmailError("이메일을 입력해 주세요.");
-      }
-      // 비밀번호 란이 비어있는 경우
-      else if (!password) {
-        setPasswordError("비밀번호를 입력해 주세요.");
-      }
+
       // 이메일, 비밀번호가 둘 다 빈 경우는 아예 버튼을 disabled 시켰기 때문에 따로 에러 메시지를 띄우지 않게 했습니다.
       window.localStorage.removeItem("accountname");
       window.localStorage.setItem("accountname", result.user.accountname);

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -3,7 +3,8 @@ import UserProfileBox from "../../modules/UserProfileBox/UserProfileBox";
 import MyProfileButton from "../../modules/MyProfileButton/MyProfileButton";
 import ProfileButton from "../../modules/ProfileButton/ProfileButton";
 
-function UserProfile({ isMe, userProfile }) {
+function UserProfile({ userProfile }) {
+  const myAccountname = window.localStorage.getItem("accountname");
   return (
     <div>
       <UserProfileBox
@@ -14,7 +15,7 @@ function UserProfile({ isMe, userProfile }) {
         followerCount={userProfile.followerCount}
         followingCount={userProfile.followingCount}
       />
-      {isMe ? (
+      {userProfile.accountname == myAccountname ? (
         <MyProfileButton />
       ) : (
         <ProfileButton isFollowing={userProfile.isFollowing} />

--- a/src/pages/AddProductPage.jsx
+++ b/src/pages/AddProductPage.jsx
@@ -4,7 +4,7 @@ import imageCompression from "browser-image-compression";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
 import AddProduct from "../components/organisms/AddProduct/AddProduct";
 
-function AddProductPage({ accountname }) {
+function AddProductPage() {
   const navigate = useNavigate();
   const [image, setImage] = useState("");
   const [name, setName] = useState("");
@@ -15,6 +15,7 @@ function AddProductPage({ accountname }) {
 
   const baseURL = "https://mandarin.api.weniv.co.kr";
   const token = window.localStorage.getItem("token");
+  const myAccountname = window.localStorage.getItem("accountname");
 
   //이미지 리사이즈
   async function handleImageSize(file) {
@@ -107,7 +108,7 @@ function AddProductPage({ accountname }) {
   //제출 버튼
   async function handleSubmit() {
     await postProduct();
-    navigate(`/profile/${accountname}`);
+    navigate(`/profile/${myAccountname}`);
   }
 
   return (

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -55,47 +55,11 @@ function ProfilePage() {
     getProducts();
   }, [accountname]);
 
-  // 더미 데이터
-  // const productArray = [
-  //   {
-  //     src: "https://img.insight.co.kr/static/2020/03/15/700/c5imbg6083e96xgj9g6f.jpg",
-  //     name: "스위치 동숲에디션 상태굿",
-  //     price: 350000,
-  //   },
-  //   {
-  //     src: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Sega-Mega-Drive-JP-Mk1-Console-Set.jpg/1024px-Sega-Mega-Drive-JP-Mk1-Console-Set.jpg",
-  //     name: "메가드라이브 s급 중고 팝니다",
-  //     price: 120000,
-  //   },
-  //   {
-  //     src: "https://www.nintendo.co.kr/hardware/modal/img/lineup/img-package--oled_white.jpg",
-  //     name: "스위치 올레드 미개봉",
-  //     price: 415000,
-  //   },
-  //   {
-  //     src: "https://blog.kakaocdn.net/dn/lJFMB/btqPaU5VmRz/yikdl5hStOQlkBM7PkfkK0/img.jpg",
-  //     name: "엑박 4세대 패드 블랙 팔아요",
-  //     price: 50000,
-  //   },
-  //   {
-  //     src: "https://image.yes24.com/usedshop/2020/1211/_/540cd528-468a-462f-8084-2314c0c8a6ba_XL.JPG",
-  //     name: "롤코타1 cd 팔아요",
-  //     price: 10000,
-  //   },
-  //   {
-  //     src: "https://mblogthumb-phinf.pstatic.net/MjAxODEwMzFfMjQ4/MDAxNTQwOTcxODcyOTEw.hNRinR5oQ0IF-Clb77oJa8lCbNog6yhf2Hisstqd_0Mg.GwLjuu2I-Fe5P-13duns4KdnpwZi7CT8EoSw7yzuGyYg.JPEG.aprileehj/image_2064034831540971847056.jpg?type=w800",
-  //     name: "플스4 레데리2 팝니다",
-  //     price: 20000,
-  //   },
-  // ];
-
   return (
     <>
       <h1 className="a11y-hidden">프로필 페이지</h1>
       <HeaderForm backButton={true} menuButton={true} />
-      {/* isMe=true이면 나의 프로필, 아니면 다른 사람의 프로필입니다. */}
-      {/* 나중에 현재 로그인된 accountname과 프로필의 accountname을 비교하면 될 거 같아요 */}
-      <UserProfile isMe={true} userProfile={profile} />
+      <UserProfile userProfile={profile} />
       <ProductList products={products} />
     </>
   );


### PR DESCRIPTION
## 작업내용
- #4 의 로그인 및 유효성 검사 기능 구현을 완료했습니다.
- 로그인한 계정의 accountname을 로컬 스토리지에 저장하여 accountname이 필요했던 페이지에서 받아오게 하였습니다.
## 레퍼런스
- useContext의 지속성: https://stackoverflow.com/questions/68548627/react-context-value-disappears-when-reloading-page
- useRef를 커스텀 컴포넌트에서 사용하는 법: https://stackoverflow.com/questions/56484686/how-do-i-avoid-function-components-cannot-be-given-refs-when-using-react-route
## 중점적으로 봐주었으면 하는 부분
- 로그인 버튼이 클릭되었을 때, 경우에 따라 에러 처리를 했습니다. 그리고 에러인 부분의 input에 포커스를 주었습니다. (이미지는 포커스되게 수정하기 전에 찍었어요..)
![image](https://user-images.githubusercontent.com/79434205/179401805-917818e3-50b2-41b1-ba5d-ae98f2c4e93e.png)
![image](https://user-images.githubusercontent.com/79434205/179401737-2b456c8b-7c70-46c0-bc02-6e8fe1e3c241.png)
![image](https://user-images.githubusercontent.com/79434205/179401725-17980c4f-da41-4591-9dad-cee0c750a3cd.png)
![image](https://user-images.githubusercontent.com/79434205/179401841-a1bcd329-0da1-4dc2-9d9b-d821a2f642de.png)

- 로그인이 정상적으로 되면 루트 페이지로 이동하도록 하였습니다.
- 기존 isMe로 내 계정인지 아닌지 대충 판별했었는데 accountname으로 제대로 판별되게 하였습니다.
![image](https://user-images.githubusercontent.com/79434205/179401577-31d90a78-cbce-400e-a279-e6dc69813258.png)
![image](https://user-images.githubusercontent.com/79434205/179401607-b5971105-a81a-4ab7-acb4-504891bec308.png)
- 상품 등록 페이지에서 저장을 누르면 저장된 accountname의 프로필 페이지로 가도록 했습니다.
## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
