### PR TITLE
Fix: Add product 페이지 이미지 프리뷰 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,10 +28,7 @@ function App() {
           element={<FollowingPage />}
         />
         <Route path="profile/edit" element={<ProfileEditPage />} />
-        <Route
-          path="/post"
-          element={<UploadPage accountname={accountname} />}
-        />
+        <Route path="/post" element={<UploadPage />} />
       </Routes>
     </div>
   );

--- a/src/pages/AddProductPage.jsx
+++ b/src/pages/AddProductPage.jsx
@@ -16,7 +16,16 @@ function AddProductPage() {
   const baseURL = "https://mandarin.api.weniv.co.kr";
   const token = window.localStorage.getItem("token");
   const myAccountname = window.localStorage.getItem("accountname");
-
+  //이미지 프리뷰
+  async function saveImage(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const image = {
+      src: URL.createObjectURL(file),
+      data: file,
+    };
+    setImage(image);
+  }
   //이미지 리사이즈
   async function handleImageSize(file) {
     const options = {
@@ -50,11 +59,6 @@ function AddProductPage() {
       console.log(error.message);
     }
   }
-  async function saveImage(event) {
-    const compressedFile = await handleImageSize(event.target.files[0]);
-    const fileUrl = await imageUpload(compressedFile);
-    setImage(fileUrl);
-  }
 
   //텍스트 저장
   function handleName(event) {
@@ -82,13 +86,13 @@ function AddProductPage() {
   }
 
   //상품 업로드
-  async function postProduct() {
+  async function postProduct(fileUrl) {
     const data = {
       product: {
         itemName: name,
         price: price,
         link: link,
-        itemImage: image,
+        itemImage: fileUrl,
       },
     };
     try {
@@ -107,7 +111,10 @@ function AddProductPage() {
 
   //제출 버튼
   async function handleSubmit() {
-    await postProduct();
+    const compressedFile = await handleImageSize(image.data);
+    const fileUrl = await imageUpload(compressedFile);
+    await postProduct(fileUrl);
+    URL.revokeObjectURL(image.src);
     navigate(`/profile/${myAccountname}`);
   }
 
@@ -118,11 +125,11 @@ function AddProductPage() {
         backButton={true}
         button="저장"
         onClick={handleSubmit}
-        active={image && name && price && link && true}
+        active={name && price && link && image && true}
       />
       <AddProduct
         saveImage={saveImage}
-        image={image}
+        image={image.src}
         handleName={handleName}
         handlePrice={handlePrice}
         handleLink={handleLink}

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -6,12 +6,13 @@ import ImageInputButton from "../../components/atoms/ImageInputButton/ImageInput
 import UploadForm from "../../components/organisms/UploadForm/UploadForm";
 import styles from "./uploadPage.module.css";
 
-function UploadPage({ accountname }) {
+function UploadPage() {
   const navigate = useNavigate();
   const [text, setText] = useState("");
   const [images, setImages] = useState([]);
   const baseURL = "https://mandarin.api.weniv.co.kr";
   const token = window.localStorage.getItem("token");
+  const myAccountname = window.localStorage.getItem("accountname");
 
   //텍스트 처리
   function handleText(event) {
@@ -125,7 +126,7 @@ function UploadPage({ accountname }) {
     await uploadData(imageNames);
     //메모리 누수 방지
     images.forEach((file) => URL.revokeObjectURL(file.src));
-    navigate(`/profile/${accountname}`);
+    navigate(`/profile/${myAccountname}`);
   }
 
   return (


### PR DESCRIPTION
## 작업내용
- #8 
Add Product 페이지에서 상품 등록 페이지의 이미지 프리뷰 기능을 이미지 변경시마다 서버에서 url을 받아오는 것이 아니라, URL.createObjectURL을 사용하도록 하여 빠르게 이미지가 변경될 수 있도록 하였습니다. 

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
