### PR TITLE
Fix: 팔로워/팔로잉 목록에서 불러오는 인원 수의 제한 해제

### DIFF
--- a/src/pages/FollowerPage.jsx
+++ b/src/pages/FollowerPage.jsx
@@ -15,7 +15,7 @@ function FollowerPage() {
 
     async function getFollowers() {
       try {
-        const data = await fetch(baseURL + `/profile/${accountname}/follower`, {
+        const data = await fetch(baseURL + `/profile/${accountname}/follower?limit=Infinity`, {
           method: "GET",
           headers: {
             Authorization: `Bearer ${token}`,

--- a/src/pages/FollowingPage.jsx
+++ b/src/pages/FollowingPage.jsx
@@ -9,14 +9,14 @@ function FollowingPage() {
   let { accountname } = useParams();
   const [followings, setFollowings] = useState([]);
 
-  useEffect(() => {
-    const baseURL = "https://mandarin.api.weniv.co.kr";
-    const token = window.localStorage.getItem("token");
+  const baseURL = "https://mandarin.api.weniv.co.kr";
+  const token = window.localStorage.getItem("token");
 
+  useEffect(() => {
     async function getFollowings() {
       try {
         const data = await fetch(
-          baseURL + `/profile/${accountname}/following`,
+          baseURL + `/profile/${accountname}/following?limit=Infinity`,
           {
             method: "GET",
             headers: {


### PR DESCRIPTION
## 작업내용
- #13 의 팔로워/팔로잉 목록에서 한 번 불러올 때 최대 10명까지밖에 안 되는 제한이 있었는데, `limit=Infinity` 쿼리를 이용해서 전체 팔로워/팔로잉 목록을 불러오도록 수정했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- limit에 한 번에 불러올 수 있는 최대 개수를 지정해줄 수 있는데, 전체를 불러오고 싶었는데 fetch 과정에서 현재 팔로잉/팔로워 수를 불러오려면 다른 fetch를 한번 더 써야 하더라고요.
그래서 우선은 제한이 없는 `Infinity`로 지정해 주었습니다. 원범님께 여쭤 보고 더 효율적인 코드가 있다면 그걸로 바꿔볼게요!
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
