### PR TITLE
Fix: 게시글에 이미지가 개수만큼 출력되게 수정

### DIFF
--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -6,6 +6,24 @@ import InfoIconGroup from "../InfoIconGroup/InfoIconGroup"
 import PostDate from "../../atoms/PostDate/PostDate"
 import styles from "./postCard.module.css"
 
+function ImageListMaker({image}) {
+  if(image.length === 1) {
+    return (
+      <ImageBox src={image[0]} type={"rounded_square"} size={"medium_large"} />
+    )
+  }else if(image.length > 1) {
+    return (
+      <ul>
+        {image.map((item, index) => (
+          <li key={index}>
+            <ImageBox src={image} type={"rounded_square"} size={"medium_small"} />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+}
+
 function PostCard({post}) {
   const author = post.author;
 
@@ -19,7 +37,7 @@ function PostCard({post}) {
           <MoreButton />
       </div>
       <p>{post.content}</p>
-      <ImageBox src={post.image} type={"rounded_square"} size={"medium_large"} />
+      <ImageListMaker image={post.image} />
       <InfoIconGroup
         postId={post.id}
         hearted={post.hearted}

--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -16,7 +16,7 @@ function ImageListMaker({image}) {
       <ul>
         {image.map((item, index) => (
           <li key={index}>
-            <ImageBox src={image} type={"rounded_square"} size={"medium_small"} />
+            <ImageBox src={image[index]} type={"rounded_square"} size={"medium_small"} />
           </li>
         ))}
       </ul>

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,4 +1,3 @@
-
 import { useState, useEffect } from "react";
 import Button from "../../components/atoms/Button/Button";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
@@ -58,12 +57,12 @@ function HomePage() {
       }
       {posts.length !== 0 && 
         <ul>
-            {
-            posts.map((post, index) => {
+          {
+            posts.map((post, index) => (
               <li key={index}>
                 <PostCard post={post}/>
               </li>
-            })
+            ))
           }
         </ul>
       }

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -29,6 +29,11 @@ function HomePage() {
           },
         });
         const result = await response.json();
+        // image 프로퍼티의 여러 개 담긴 image url을 나눠 배열로 만듭니다.
+        const postData = result.posts.map(
+          (item) => (item.image.split(", "))
+        );
+        console.log(postData);
         setPosts(result.posts);
       } catch (error) {
         console.log(error.message);

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -30,11 +30,19 @@ function HomePage() {
         });
         const result = await response.json();
         // image 프로퍼티의 여러 개 담긴 image url을 나눠 배열로 만듭니다.
-        const postData = result.posts.map(
+        const imageData = result.posts.map(
           (item) => (item.image.split(", "))
         );
-        console.log(postData);
+        
+        // posts의 각 게시글 image 프로퍼티를 처리된 imageData로 대체합니다.
+        result.posts.map((post, index) => {
+          post.image = imageData[index];
+        })
+
+        console.log(result);
         setPosts(result.posts);
+        console.log(posts);
+        
       } catch (error) {
         console.log(error.message);
       }


### PR DESCRIPTION
## 작업내용
#75
홈피드에 게시글 데이터를 불러올 때, image 프로퍼티에 여러 개의 이미지의 경우 `"{url}, {url}, ..."` 와 같이 문자열 형식으로 가져와 이미지가 정상 출력되지 않는 문제가 있었습니다.

- HomePage.jsx에서 게시글 데이터 불러올 때 각 포스트의 image 프로퍼티의 정보를 배열로 변경
- PostCard.jsx에서 props로 받은 이미지 URL 배열 요소 개수만큼 이미지를 출력하게 수정

결과입니다. 
![image](https://user-images.githubusercontent.com/102221305/179669345-ede21166-9abf-4836-b8be-64b1f026f9ab.png)

## 중점적으로 봐주었으면 하는 부분

이미지 url의 개수대로 이미지 컴포넌트가 생성되었으나, **교차 출처 읽기 차단(CORB)으로 인해** 소스를 제대로 가져오지 못하는 문제가 있어 이슈로 등록하였습니다. #76 
![image](https://user-images.githubusercontent.com/102221305/179670913-0576223b-f05d-438c-91b4-80dd769b6925.png)

==========
**이미지 주소를 잘못 전달하고 있어 수정했습니다! 정상적으로 이미지가 나옵니다.**
![image](https://user-images.githubusercontent.com/102221305/179673491-e1a697b5-8eee-45a7-acfd-25676c73781b.png)


## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
