### PR TITLE
Fix: 이미지 url을 콤마로만 구분하도록 변경

### DIFF
--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -3,7 +3,7 @@ import Button from "../../components/atoms/Button/Button";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import PostCard from "../../components/modules/PostCard/PostCard";
 import catImageURL from "../../assets/icon-404-cat.png";
-import styles from "./homePage.module.css"
+import styles from "./homePage.module.css";
 
 function HomePage() {
   const [posts, setPosts] = useState([]);
@@ -12,7 +12,7 @@ function HomePage() {
   // 보지 않을 포스트 개수를 post_skip에 저장합니다. 이후 skip_amount만큼 증가합니다.
   let post_skip = 0;
   // const skip_amount = 5;
-  
+
   const BASE_URL = "https://mandarin.api.weniv.co.kr";
   const REQ_PATH = `/post/feed/?limit=${post_limit}&skip=${post_skip}`;
   const TOKEN = window.localStorage.getItem("token");
@@ -30,19 +30,16 @@ function HomePage() {
         });
         const result = await response.json();
         // image 프로퍼티의 여러 개 담긴 image url을 나눠 배열로 만듭니다.
-        const imageData = result.posts.map(
-          (item) => (item.image.split(", "))
-        );
-        
+        const imageData = result.posts.map((item) => item.image.split(","));
+
         // posts의 각 게시글 image 프로퍼티를 처리된 imageData로 대체합니다.
         result.posts.map((post, index) => {
           post.image = imageData[index];
-        })
+        });
 
         console.log(result);
         setPosts(result.posts);
         console.log(posts);
-        
       } catch (error) {
         console.log(error.message);
       }
@@ -54,8 +51,12 @@ function HomePage() {
   // post 배열의 길이가 1이 아니면 PostCard로 List를 만듭니다.
   return (
     <>
-      <HeaderForm title={"감귤마켓 피드"} searchButton={true} titleSize={"large"} />
-      {posts.length === 0 && 
+      <HeaderForm
+        title={"감귤마켓 피드"}
+        searchButton={true}
+        titleSize={"large"}
+      />
+      {posts.length === 0 && (
         <div className={styles["container-search_notice"]}>
           <img src={catImageURL} />
           <p className={styles["text"]}>유저를 검색해 팔로우 해보세요!</p>
@@ -67,20 +68,18 @@ function HomePage() {
             primary={true}
           />
         </div>
-      }
-      {posts.length !== 0 && 
+      )}
+      {posts.length !== 0 && (
         <ul>
-          {
-            posts.map((post, index) => (
-              <li key={index}>
-                <PostCard post={post}/>
-              </li>
-            ))
-          }
+          {posts.map((post, index) => (
+            <li key={index}>
+              <PostCard post={post} />
+            </li>
+          ))}
         </ul>
-      }
+      )}
     </>
-  )
+  );
 }
 
 export default HomePage;

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -99,7 +99,7 @@ function UploadPage() {
     const imageData = imageNames
       .split(",")
       .map((name) => baseURL + "/" + name)
-      .join(", ");
+      .join(",");
     const data = {
       post: {
         content: text,


### PR DESCRIPTION
## 작업내용
이미지 url 여러개를 서버에 보낼 경우 ', '(콤마+공백) 에서 ',' (콤마)로만 구분하도록 변경하였습니다 :)

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
