### PR TITLE
Feat: Post 상세보기 페이지 post 데이터 및 댓글 데이터 불러오기 기능 추가 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import UploadPage from "./pages/UploadPage/UploadPage";
 import FollowerPage from "./pages/FollowerPage";
 import FollowingPage from "./pages/FollowingPage.jsx";
 import HomePage from "./pages/HomePage/HomePage";
+import PostPage from "./pages/PostPage";
 
 function App() {
   return (
@@ -29,10 +30,8 @@ function App() {
           element={<FollowingPage />}
         />
         <Route path="profile/edit" element={<ProfileEditPage />} />
-        <Route
-          path="/post"
-          element={<UploadPage />}
-        />
+        <Route path="/post" element={<UploadPage />} />
+        <Route path="/post/:postId" element={<PostPage />} />
       </Routes>
     </div>
   );

--- a/src/components/atoms/IconButton/iconButton.module.css
+++ b/src/components/atoms/IconButton/iconButton.module.css
@@ -20,6 +20,12 @@
   background-image: url(../../../assets/icon-more-vertical.svg);
 }
 
+.more {
+  width: 18px;
+  height: 18px;
+  background-image: url(../../../assets/icon-more-vertical-small.svg);
+}
+
 .close {
   background-image: url(../../../assets/x.svg);
 }

--- a/src/components/modules/CommentForm/CommentForm.jsx
+++ b/src/components/modules/CommentForm/CommentForm.jsx
@@ -1,0 +1,24 @@
+import styles from "./commentForm.module.css";
+import IconButton from "../../atoms/IconButton/IconButton";
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+
+function CommentForm({ src, userName, createTime, text }) {
+  function handleMoreButton() {
+    console.log("더보기");
+  }
+  return (
+    <div className={styles["wrapper-comment"]}>
+      <div className={styles["wrapper-upper"]}>
+        <ImageBox src={src} type="circle" size="small" alt="프로필 이미지" />
+        <div className={styles["comment_info"]}>
+          <strong>{userName}</strong>
+          <small>{`· ${createTime}`}</small>
+        </div>
+        <IconButton type="more" onClick={handleMoreButton} />
+      </div>
+      <p className={styles["text"]}>{text}</p>
+    </div>
+  );
+}
+
+export default CommentForm;

--- a/src/components/modules/CommentForm/commentForm.module.css
+++ b/src/components/modules/CommentForm/commentForm.module.css
@@ -1,0 +1,26 @@
+.wrapper-upper {
+  display: flex;
+  align-items: center;
+}
+
+.comment_info {
+  display: flex;
+  align-items: center;
+  margin-left: 12px;
+  flex-grow: 1;
+}
+
+.comment_info strong {
+  font-size: 1.4rem;
+  font-weight: 500;
+}
+
+.comment_info small {
+  margin-left: 6px;
+  color: var(--darkgray-color);
+}
+
+.text {
+  margin: 4px 15px auto 48px;
+  font-size: 1.4rem;
+}

--- a/src/components/modules/HeaderForm/HeaderForm.jsx
+++ b/src/components/modules/HeaderForm/HeaderForm.jsx
@@ -23,8 +23,10 @@ function HeaderForm({
         <IconButton type="back" text="뒤로 가기" onClick={() => navigate(-1)} />
       )}
       {title && <h1 className={styles[titleSize]}>{title}</h1>}
-      {searchButton && <IconButton type="search" text="검색" onClick={""} />}
-      {menuButton && <IconButton type="menu" text="더보기" onClick={""} />}
+      {searchButton && (
+        <IconButton type="search" text="검색" onClick={onClick} />
+      )}
+      {menuButton && <IconButton type="menu" text="더보기" onClick={onClick} />}
       {button && (
         <Button
           size="medium_small"

--- a/src/components/modules/InfoIconGroup/InfoIconGroup.jsx
+++ b/src/components/modules/InfoIconGroup/InfoIconGroup.jsx
@@ -3,13 +3,13 @@ import Like from "../../atoms/Like/Like";
 import Comment from "../../atoms/Comment/Comment";
 import styles from "./infoIconGroup.module.css";
 
-function InfoIconGroup({postId, hearted, heartCount, commentCount}) {
+function InfoIconGroup({ postId, hearted, heartCount, commentCount }) {
   return (
     <div className={styles["container-icon"]}>
-      <Like postId={postId} hearted={hearted} heartCount={heartCount}/>
-      <Comment commentCount={commentCount}/>
+      <Like postId={postId} hearted={hearted} heartCount={heartCount} />
+      <Comment postId={postId} commentCount={commentCount} />
     </div>
-  )
+  );
 }
 
 export default InfoIconGroup;

--- a/src/components/modules/MessageInput/messageInput.module.css
+++ b/src/components/modules/MessageInput/messageInput.module.css
@@ -1,10 +1,11 @@
 .wrapper-comment {
   margin: auto;
   max-width: 800px;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   right: 0;
   left: 0;
+  background-color: white;
   display: flex;
   padding: 12.5px 16px 12px;
   border-top: 1px solid var(--lightgray-color);

--- a/src/components/modules/MessageInput/messageInput.module.css
+++ b/src/components/modules/MessageInput/messageInput.module.css
@@ -1,4 +1,10 @@
 .wrapper-comment {
+  margin: auto;
+  max-width: 800px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
   display: flex;
   padding: 12.5px 16px 12px;
   border-top: 1px solid var(--lightgray-color);

--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -1,40 +1,45 @@
-import React from "react"
-import ImageBox from "../../atoms/ImageBox/ImageBox"
-import Author from "../../atoms/Author/Author"
-import MoreButton from "../../atoms/MoreButton/MoreButton"
-import InfoIconGroup from "../InfoIconGroup/InfoIconGroup"
-import PostDate from "../../atoms/PostDate/PostDate"
-import styles from "./postCard.module.css"
+import React from "react";
+import ImageBox from "../../atoms/ImageBox/ImageBox";
+import Author from "../../atoms/Author/Author";
+import MoreButton from "../../atoms/MoreButton/MoreButton";
+import InfoIconGroup from "../InfoIconGroup/InfoIconGroup";
+import PostDate from "../../atoms/PostDate/PostDate";
+import styles from "./postCard.module.css";
 
-function ImageListMaker({image}) {
-  if(image.length === 1) {
+function ImageListMaker({ image }) {
+  const imageData = image.split(",");
+  if (image.length === 1) {
     return (
       <ImageBox src={image[0]} type={"rounded_square"} size={"medium_large"} />
-    )
-  }else if(image.length > 1) {
+    );
+  } else if (image.length > 1) {
     return (
       <ul>
-        {image.map((item, index) => (
+        {imageData.map((item, index) => (
           <li key={index}>
-            <ImageBox src={image[index]} type={"rounded_square"} size={"medium_small"} />
+            <ImageBox
+              src={item}
+              type={"rounded_square"}
+              size={"medium_small"}
+            />
           </li>
         ))}
       </ul>
-    )
+    );
   }
 }
 
-function PostCard({post}) {
+function PostCard({ post }) {
   const author = post.author;
 
   return (
     <article className={styles["container-post"]}>
       <div className={styles["profile"]}>
-        <ImageBox type={"circle"} size={"medium_small"}/>
+        <ImageBox type={"circle"} size={"medium_small"} />
       </div>
       <div className={styles["container-user"]}>
-          <Author authorName={author.username} authorId={author._id}/>
-          <MoreButton />
+        <Author authorName={author.username} authorId={author._id} />
+        <MoreButton />
       </div>
       <p>{post.content}</p>
       <ImageListMaker image={post.image} />
@@ -46,7 +51,7 @@ function PostCard({post}) {
       />
       <PostDate date={post.createdAt} />
     </article>
-  )
+  );
 }
 
-export default PostCard
+export default PostCard;

--- a/src/components/modules/PostCard/postCard.module.css
+++ b/src/components/modules/PostCard/postCard.module.css
@@ -1,4 +1,5 @@
 .container-post {
+  box-sizing: border-box;
   width: 100%;
   padding: 20px 16px;
   display: grid;

--- a/src/components/organisms/CommentList/CommentList.jsx
+++ b/src/components/organisms/CommentList/CommentList.jsx
@@ -1,0 +1,41 @@
+import styles from "./commentList.module.css";
+import CommentForm from "../../modules/CommentForm/CommentForm";
+
+function getTimeStamp(createdAt) {
+  const createTime = new Date(createdAt);
+  const now = new Date();
+  const elapsedSec = (now.getTime() - createTime.getTime()) / 1000;
+  const elapsedMin = elapsedSec / 60;
+  const elapsedHour = elapsedMin / 60;
+  const elapsedDay = elapsedHour / 24;
+  const elapsedMonth = elapsedDay / 30;
+  const elapsedYear = elapsedMonth / 12;
+  if (elapsedSec < 61) return `${Math.floor(elapsedSec)}초 전`;
+  if (elapsedMin < 61) return `${Math.floor(elapsedMin)}분 전`;
+  if (elapsedHour < 25) return `${Math.floor(elapsedHour)}시간 전`;
+  if (elapsedDay < 31) return `${Math.floor(elapsedDay)}일 전`;
+  if (elapsedMonth < 13) return `${Math.floor(elapsedMonth)}달 전`;
+  return `${Math.floor(elapsedYear)}년 전`;
+}
+
+function CommentList({ comments }) {
+  //날짜 계산
+  return (
+    <ul className={styles["wrapper-comment"]}>
+      {comments.map((item) => {
+        return (
+          <li key={item.id}>
+            <CommentForm
+              src={item.author.image}
+              userName={item.author.username}
+              createTime={getTimeStamp(item.createdAt)}
+              text={item.content}
+            />
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default CommentList;

--- a/src/components/organisms/CommentList/commentList.module.css
+++ b/src/components/organisms/CommentList/commentList.module.css
@@ -1,0 +1,7 @@
+.wrapper-comment {
+  padding: 4px 16px 16px;
+}
+
+.wrapper-comment li {
+  margin-top: 16px;
+}

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -29,15 +29,13 @@ function HomePage() {
           },
         });
         const result = await response.json();
-        // image 프로퍼티의 여러 개 담긴 image url을 나눠 배열로 만듭니다.
-        const imageData = result.posts.map((item) => item.image.split(","));
+        // // image 프로퍼티의 여러 개 담긴 image url을 나눠 배열로 만듭니다.
+        // const imageData = result.posts.map((item) => item.image.split(","));
 
-        // posts의 각 게시글 image 프로퍼티를 처리된 imageData로 대체합니다.
-        result.posts.map((post, index) => {
-          post.image = imageData[index];
-        });
-
-        console.log(result);
+        // // posts의 각 게시글 image 프로퍼티를 처리된 imageData로 대체합니다.
+        // result.posts.map((post, index) => {
+        //   post.image = imageData[index];
+        // });
         setPosts(result.posts);
         console.log(posts);
       } catch (error) {

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
+import PostCard from "../components/modules/PostCard/PostCard";
+import CommentList from "../components/organisms/CommentList/CommentList";
+import MessageInput from "../components/modules/MessageInput/MessageInput";
+
+function PostPage() {
+  let { postId } = useParams();
+  const [post, setPost] = useState();
+  const [comments, setComments] = useState([]);
+  const BASE_URL = "https://mandarin.api.weniv.co.kr";
+  const TOKEN = window.localStorage.getItem("token");
+  const reqData = {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      "Content-type": "application/json",
+    },
+  };
+
+  useEffect(() => {
+    async function getPostData() {
+      try {
+        const response = await fetch(BASE_URL + `/post/${postId}`, reqData);
+        const result = await response.json();
+        setPost(result.post);
+      } catch (error) {
+        console.log(error.message);
+      }
+    }
+
+    async function getPostComment() {
+      try {
+        const response = await fetch(
+          BASE_URL + `/post/${postId}/comments`,
+          reqData
+        );
+        const result = await response.json();
+        setComments(result.comments.reverse());
+      } catch (error) {
+        console.log(error.message);
+      }
+    }
+    getPostData();
+    getPostComment();
+  }, [postId]);
+
+  return (
+    <>
+      <HeaderForm backButton={true} menuButton={true} />
+      {post && <PostCard post={post} />}
+      {comments && <CommentList comments={comments} />}
+      <MessageInput
+        type="comment"
+        src=""
+        title="댓글"
+        placeholder="댓글 입력하기..."
+        buttonText="게시"
+      />
+    </>
+  );
+}
+
+export default PostPage;


### PR DESCRIPTION
## 작업내용
- #9 
- 피드에서 댓글 아이콘을 클릭하면 /post/:postId 경로로 이동합니다. 
- 해당 피드의 postId를 받아와 피드 상세 정보와 댓글 리스트를 불러옵니다. 
- 댓글이 몇일전 작성한 것인지 나타내 주는 기능도 추가하였습니다. 
- 헤더 컴포넌트에서 계속 발생하는 onClick 오류를 해결하였습니다.
### 1) 예시 사진1
![image](https://user-images.githubusercontent.com/68495264/179750940-3896d1f2-4def-45a1-ac5f-507e0c87eb8c.png)
### 2) 예시 사진 2
![image](https://user-images.githubusercontent.com/68495264/179751012-039d92bc-870f-492b-8381-02404e20fed3.png)

## 중점적으로 봐줬으면 하는 부분
- @yeodahui 님!!  Post 상세 보기 페이지에서도, 이미지 url split 가 필요해서, 해당 기능을 HomePage -> PostCard 컴포넌트로 이동하였습니다!! 어떤 부분을 수정했는지 보여드려야 할 것같아 HomePage.jsx에서 해당 부분은 주석처리 해놓았습니다!!
- useEffect에서 데이터를 불러오는 것이 페이지 render보다 오래걸려서 계속 데이터가 페이지에 undefined로 나타난 이슈가 있었습니다.. 하루종일 뻘짓 했습니다ㅠㅠ 흑흑 
혹시나 이런 경험 하실까봐 공유해드려요 [참고 스택오버플로우](https://stackoverflow.com/questions/65687852/fetch-data-inside-useeffect-hook-before-rendering-react)
=> 결론 (데이터가 있을때만 해당 컴포넌트가 보여지게 조건문을 달아라^^
```
{post && <PostCard post={post} />}
{comments && <CommentList comments={comments} />}
```

## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
