### PR TITLE
Design: Header 컴포넌트를 fixed로 고정 

### DIFF
--- a/src/components/modules/HeaderForm/headerForm.module.css
+++ b/src/components/modules/HeaderForm/headerForm.module.css
@@ -1,4 +1,11 @@
 .wrapper-header {
+  margin: auto;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  max-width: 800px;
+  background-color: white;
   height: 32px;
   padding: 8px 16px 7.5px;
   display: flex;

--- a/src/global.css
+++ b/src/global.css
@@ -12,6 +12,10 @@ html {
   font-size: 10px;
 }
 
+body {
+  padding-top: 48px;
+}
+
 a {
   text-decoration: none;
   color: inherit;


### PR DESCRIPTION
## 작업내용
- 내용이 많아져 스크롤 할떄 헤더가 상단에 고정되도록 하였습니다. 

![image](https://user-images.githubusercontent.com/68495264/179878888-60976d10-b535-4b1f-a9f7-3d8381cd415e.png)

- **로그인, 이메일로 회원가입 페이지**를 제외하고는 모두 헤더가 있어서, **global.css**에서 body에 padding-top을 부여하였습니다.
로그인 페이지에서 padding-top이 추가로 부여되어 컨텐츠가 아래로 조금 내려간 모습입니다. 
사실 이게 중앙에 배치되어 더 예뻐보이긴 하는데,, 피그마 대로 해야한다고 하면 어떻게 효율적으로 수정할지 고민해보겠습니다ㅎㅎㅎ😂 의견남겨주세요
 
![image](https://user-images.githubusercontent.com/68495264/179879074-f812bd50-d607-40be-a0ca-e210ca20612f.png)


## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
