### PR TITLE
Feat: 채팅목록 페이지 마크업 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import ErrorPage from "./pages/ErrorPage/ErrorPage";
 import HomePage from "./pages/HomePage/HomePage";
 import PostPage from "./pages/PostPage";
 import SearchPage from "./pages/SearchPage/SearchPage";
+import ChatListPage from "./pages/ChatListPage/ChatListPage";
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/search" element={<SearchPage />} />
+        <Route path="/chat" element={<ChatListPage />} />
         <Route path="/user" element={<JoinPage />} />
         <Route path="/product" element={<AddProductPage />} />
         <Route path="/profile/:accountname" element={<ProfilePage />} />

--- a/src/pages/ChatListPage/ChatListPage.jsx
+++ b/src/pages/ChatListPage/ChatListPage.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import ImageBox from "../../components/atoms/ImageBox/ImageBox";
+import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
+import styles from "./chatListPage.module.css";
+
+function ChatListPage() {
+  // 더미 데이터
+  const item1 = {
+    username: "지상 최강의 뉴비",
+    message: "주인공 이름이 젤다인가요?",
+    date: "2020.10.25",
+  };
+  const item2 = {
+    username: "애국자",
+    message: "동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세",
+    date: "2020.10.25",
+  }
+  const chatData = [item1, item2];
+  console.log(chatData)
+
+  return (
+    <section>
+      <h1 className="a11y-hidden">채팅목록</h1>
+      <HeaderForm backButton={true} menuButton={true} />
+      <ul className={styles["list-chat"]}>
+        {chatData.map((item, index) => (
+          <li key={index} className={styles["item-chat"]}>
+            <div className={styles.left}>
+              <ImageBox type={"circle"} size={"medium_small"} />
+            </div>
+            <div className={styles.right}>
+                <strong className={styles.username}>
+                  {item.username}
+                </strong>
+              <div>
+                <span className={styles.message}>
+                  {item.message}
+                </span>
+                <span className={styles.date}>
+                  {item.date}
+                </span>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      
+    </section>
+  )
+}
+
+export default ChatListPage

--- a/src/pages/ChatListPage/ChatListPage.jsx
+++ b/src/pages/ChatListPage/ChatListPage.jsx
@@ -9,11 +9,13 @@ function ChatListPage() {
     username: "지상 최강의 뉴비",
     message: "주인공 이름이 젤다인가요?",
     date: "2020.10.25",
+    read: false,
   };
   const item2 = {
     username: "애국자",
     message: "동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세",
     date: "2020.10.25",
+    read: true,
   }
   const chatData = [item1, item2];
   console.log(chatData)
@@ -25,7 +27,7 @@ function ChatListPage() {
       <ul className={styles["list-chat"]}>
         {chatData.map((item, index) => (
           <li key={index} className={styles["item-chat"]}>
-            <div className={styles.left}>
+            <div className={`${styles.left} ${item.read ? "" : styles.unread}`}>
               <ImageBox type={"circle"} size={"medium_small"} />
             </div>
             <div className={styles.right}>

--- a/src/pages/ChatListPage/ChatListPage.jsx
+++ b/src/pages/ChatListPage/ChatListPage.jsx
@@ -34,7 +34,7 @@ function ChatListPage() {
                 <strong className={styles.username}>
                   {item.username}
                 </strong>
-              <div>
+              <div className={styles["info-message"]}>
                 <span className={styles.message}>
                   {item.message}
                 </span>

--- a/src/pages/ChatListPage/chatListPage.module.css
+++ b/src/pages/ChatListPage/chatListPage.module.css
@@ -44,14 +44,25 @@
   letter-spacing: 0em;
 }
 
+.info-message {
+  min-width: 20rem;
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  grid-gap: 12px;
+  gap: 12px;
+}
+
 .message {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 1.2rem;
   font-weight: 400;
   color: var(--darkgray-color);
 }
 
 .date {
-  float: right;
+  display: inline-block;
   font-size: 1rem;
   color: var(--lightgray-color);
 }

--- a/src/pages/ChatListPage/chatListPage.module.css
+++ b/src/pages/ChatListPage/chatListPage.module.css
@@ -18,7 +18,7 @@
   margin-right: 10px;
 }
 
-.left::after {
+.left.unread::after {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/pages/ChatListPage/chatListPage.module.css
+++ b/src/pages/ChatListPage/chatListPage.module.css
@@ -1,0 +1,57 @@
+.list-chat {
+  padding: 24px 16px;
+}
+
+.item-chat {
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.item-chat:not(:last-of-type) {
+  margin-bottom: 20px;
+}
+
+.left {
+  position: relative;
+  flex-grow: 0;
+  flex-shrink: 0;
+  margin-right: 10px;
+}
+
+.left::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  content: "";
+  width: 12px;
+  height: 12px;
+  background-color: var(--main-color);
+  border-radius: 50%;
+}
+
+.right {
+  padding: 2px;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.username {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 1.4rem;
+  font-weight: 400;
+  line-height: 18px;
+  letter-spacing: 0em;
+}
+
+.message {
+  font-size: 1.2rem;
+  font-weight: 400;
+  color: var(--darkgray-color);
+}
+
+.date {
+  float: right;
+  font-size: 1rem;
+  color: var(--lightgray-color);
+}


### PR DESCRIPTION
## 작업내용
#6 채팅 목록 페이지 마크업을 구현하였습니다. 더미 데이터를 이용해 API와 연동 시 데이터를 쉽게 넣을 수 있도록 만들었습니다.
![image](https://user-images.githubusercontent.com/102221305/179934322-843ab3a9-def3-4a9b-93cf-c04641899758.png)

- 채팅 목록 페이지 생성 및 라우트에 연결(/chat)
- 읽지 않은 채팅 표시
- 채팅목록에서 메시지가 길 때 말줄임

메세지 블럭과 날짜 블럭을 나란히 둬야 해서 부모 요소에 flex 태그를 주었더니, 말줄임이 안되더라고요.
flex 박스는 flex-wrap이 nowrap일 경우 콘텐츠 너비 이상으로 박스가 줄어들지 않기 때문이었습니다.
flex 대신 grid를 사용했더니 정상적으로 적용되었습니다.

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
