### PR TITLE
Fix: Post card 이미지가 ImageBox 컴포넌트에 꽉차지 않는 문제 해결

### DIFF
--- a/src/components/atoms/ImageBox/ImageBox.jsx
+++ b/src/components/atoms/ImageBox/ImageBox.jsx
@@ -4,7 +4,7 @@ import styles from "./imageBox.module.css";
 function ImageBox({ src, type, size, alt }) {
   return (
     <div className={`${styles["image"]} ${styles[type]} ${styles[size]}`}>
-      <img src={src} alt={alt} />
+      {src && <img src={src} alt={alt} />}
     </div>
   );
 }

--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -1,15 +1,12 @@
 .image {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   box-sizing: border-box;
   border: 0.5px solid var(--lightgray-color);
   overflow: hidden;
 }
 
 .image img {
-  max-width: 100%;
-  max-height: 100%;
+  height: 100%;
+  width: 100%;
   object-fit: cover;
 }
 
@@ -73,6 +70,7 @@
 
 /* 게시글에서 사용될 이미지입니다. */
 .rounded_square.medium_large {
+  height: 304px;
   max-width: 400px;
 }
 
@@ -80,4 +78,5 @@
 .rounded_square.large {
   width: 320px;
   height: 204px;
+  background-color: var(--whitegray-color);
 }

--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -10,11 +10,9 @@ function ImageListMaker({ image }) {
   const imageData = image.split(",");
   console.dir(imageData);
   console.log(imageData.length);
-  if (imageData.length == 1) {
-    return (
-      <ImageBox src={imageData} type={"rounded_square"} />
-    );
-  } else if (imageData.length > 1) {
+  //이미지가 없을 경우 빈 태그 리턴
+  if (!image) return <></>;
+  else {
     return (
       <ul className={styles["list-images"]}>
         {imageData.map((item, index) => (
@@ -22,6 +20,7 @@ function ImageListMaker({ image }) {
             <ImageBox
               src={item}
               type={"rounded_square"}
+              size={"medium_large"}
             />
           </li>
         ))}
@@ -40,7 +39,7 @@ function PostCard({ post }) {
       </div>
       <div className={styles["container-user"]}>
         <Author authorName={author.username} authorId={author.accountname} />
-        <IconButton type={"more"} text={"더보기"} onClick={()=>{}} />
+        <IconButton type={"more"} text={"더보기"} onClick={() => {}} />
       </div>
       <p className={styles["content"]}>{post.content}</p>
       <ImageListMaker image={post.image} />

--- a/src/components/modules/PostCard/postCard.module.css
+++ b/src/components/modules/PostCard/postCard.module.css
@@ -25,6 +25,10 @@
 }
 
 .list-images {
+  box-sizing: border-box;
+  margin: 0 auto;
+  height: 314px;
+  max-width: 400px;
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
@@ -38,6 +42,7 @@
 .item-image {
   flex-shrink: 0;
   width: 100%;
+  height: 100%;
 }
 
 .item-image:not(:last-of-type) {

--- a/src/components/organisms/CommentList/commentList.module.css
+++ b/src/components/organisms/CommentList/commentList.module.css
@@ -1,5 +1,6 @@
 .wrapper-comment {
   padding: 4px 16px 16px;
+  border-top: 1px solid var(--lightgray-color);
 }
 
 .wrapper-comment li {

--- a/src/global.css
+++ b/src/global.css
@@ -40,3 +40,20 @@ a {
 .wrapper-padding {
   padding: 34px;
 }
+
+/* scroll */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--middlegray-color);
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background-color: transparent;
+  border-radius: 10px;
+  box-shadow: inset 0px 0px 5px white;
+}


### PR DESCRIPTION
## 작업내용
- ImageBox 컴포넌트에서 이미지가 꽉차지않는 문제를 수정해보았습니다. 
- postCard에서 받은 이미지 데이터가 없어도 ImageBox가 불려지는 점을 수정하였습니다. ( PostCard.jsx의 ImageListMaker 컴포넌트수정)

### 1) ul 리스트 스크롤 
- ul 사이즈과 이미지 사이즈는  height를 고정시키고, width는 max-width를 사용하여 줄어들 수 있도록 하였습니다. 
![image](https://user-images.githubusercontent.com/68495264/180008172-266ecdca-c52b-4b4d-b99f-b749dfed4f5b.png)

![image](https://user-images.githubusercontent.com/68495264/180008272-21d5a9af-e17c-4133-b145-85dddf758890.png)

### 2) 다른 이미지들 중앙 배치 확인
- ImageBox에서 다른 이미지들도 모두 이미지 중앙을 기준으로 배치되었는지 확인하였습니다. 
![image](https://user-images.githubusercontent.com/68495264/180008830-471dd5d3-83d2-4b47-b5ff-23c9ad997fb9.png)
![image](https://user-images.githubusercontent.com/68495264/180008856-42c9425d-91fa-49c3-a0f5-27b5e8e2a7be.png)


## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [ ]  의미 있는 커밋 메시지를 작성하셨나요?
