### PR TITLE
Fix: ImageBox 작은 이미지 깨짐 현상 수정

### DIFF
--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -1,12 +1,15 @@
 .image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   box-sizing: border-box;
   border: 0.5px solid var(--lightgray-color);
   overflow: hidden;
 }
 
 .image img {
-  height: 100%;
-  width: 100%;
+  max-height: 100%;
+  max-width: 100%;
   object-fit: cover;
 }
 
@@ -72,6 +75,11 @@
 .rounded_square.medium_large {
   height: 304px;
   max-width: 400px;
+}
+
+.rounded_square.medium_large img {
+  height: 100%;
+  width: 100%;
 }
 
 /* 상품 등록 페이지에서 사용될 이미지입니다. */


### PR DESCRIPTION
## 작업내용
imageBox에서 
```
.image img {
  height: 100%;
  width: 100%;
  object-fit: cover;
}
```
했더니 작은 이미지가 깨지네요 따이쉬..
![image](https://user-images.githubusercontent.com/68495264/180113248-1bedb485-e1c1-468f-8949-0db2632c23b5.png)

기본 설정을 원래대로 돌려주고 게시글에서만 적용되도록 해주었습니다. 
```
.rounded_square.medium_large img {
  height: 100%;
  width: 100%;
}
```

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
