### PR TITLE
Desing: Upload 페이지 UI 개선

### DIFF
--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -1,12 +1,15 @@
 .image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   box-sizing: border-box;
   border: 0.5px solid var(--lightgray-color);
   overflow: hidden;
 }
 
 .image img {
-  height: 100%;
-  width: 100%;
+  max-height: 100%;
+  max-width: 100%;
   object-fit: cover;
 }
 
@@ -79,4 +82,9 @@
   width: 320px;
   height: 204px;
   background-color: var(--whitegray-color);
+}
+
+.rounded_square img {
+  height: 100%;
+  width: 100%;
 }

--- a/src/components/atoms/TextArea/textArea.module.css
+++ b/src/components/atoms/TextArea/textArea.module.css
@@ -1,6 +1,5 @@
 .input-text {
-  margin-left: 12px;
-  width: 100%;
+  max-height: 60vh;
   resize: none;
   outline: none;
   border: none;

--- a/src/components/atoms/TextArea/textArea.module.css
+++ b/src/components/atoms/TextArea/textArea.module.css
@@ -4,6 +4,7 @@
   outline: none;
   border: none;
   font-size: 1.4rem;
+  line-height: 18px;
 }
 
 .input-text::placeholder {

--- a/src/components/modules/UploadText/uploadText.module.css
+++ b/src/components/modules/UploadText/uploadText.module.css
@@ -1,5 +1,6 @@
 .wrapper-post {
-  display: flex;
+  display: grid;
+  grid-template-columns: 42px 1fr;
 }
 
 .wrapper-post > textarea {

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -142,7 +142,9 @@ function UploadPage() {
         handleText={handleText}
         handleDeleteBtn={handleDeleteBtn}
       />
-      <ImageInputButton saveImage={saveImage} size="medium" multiple={true} />
+      <div className={styles["wrapper-bottom"]}>
+        <ImageInputButton saveImage={saveImage} size="medium" multiple={true} />
+      </div>
     </div>
   );
 }

--- a/src/pages/UploadPage/uploadPage.module.css
+++ b/src/pages/UploadPage/uploadPage.module.css
@@ -1,14 +1,17 @@
-.wrapper-page {
-  height: 100vh;
-  position: relative;
-}
-
 .wrapper-page > div:nth-child(2) {
   padding: 20px 16px 16px;
 }
 
-.wrapper-page > div:last-child {
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
+.wrapper-bottom {
+  margin: auto;
+  max-width: 800px;
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  background-color: white;
+}
+
+.wrapper-bottom button {
+  margin: 0 16px 16px auto;
 }


### PR DESCRIPTION
## 작업내용
 - #10 
   - 텍스트 입력이 **화면 height의 60퍼센트**를 넘어가면 스크롤되도록 하였습니다. 
   - flex를 사용했더니 프로필 이미지 박스가 찌그러져 **grid로 변경**하였습니다. 
  
- #61   
  - ImageBox 컴포넌트에서 모든 .rounded_square img 에만 height: 100%;
    width: 100% 이 적용하여 이미지가 박스에 꽉차도록 해주었습니다. 

  (circle의 경우 위와 같이 적용하니 작은 박스에서 이미지가 깨지는 현상이 있어 max-height max-width로 남겨놨습니다)

![image](https://user-images.githubusercontent.com/68495264/180119939-3aca1590-bc26-4073-bf38-df7eed25a3cf.png)
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
