### PR TITLE
Design: PostCard 게시물 작성 유저 이미지 추가

### DIFF
--- a/src/components/atoms/Comment/Comment.jsx
+++ b/src/components/atoms/Comment/Comment.jsx
@@ -1,15 +1,14 @@
 import { Link } from "react-router-dom";
 import styles from "./comment.module.css";
 
-function Comment({postId, commentCount}) {
-  console.log(commentCount)
+function Comment({ postId, commentCount }) {
   return (
     <div className={styles["container-comment"]}>
       <p className="a11y-hidden">댓글</p>
       <Link to={`/post/${postId}`} className={styles["link-comment"]} />
       <span className={styles["count-comment"]}>{commentCount}</span>
     </div>
-  )
+  );
 }
 
 export default Comment;

--- a/src/components/atoms/PostDate/PostDate.jsx
+++ b/src/components/atoms/PostDate/PostDate.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import styles from "./postDate.module.css";
 
 function PostDate({ date }) {
-  // 더미 데이터로 오늘 날짜가 찍히게 만들었습니다.
   date = new Date(date);
 
   // date를 xxxx년 x월 x일의 형태로 출력되게끔 string을 만듭니다.

--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -41,7 +41,7 @@ function PostCard({ post }) {
       </div>
       <div className={styles["content"]}>
         {post.content.split("\n").map((line, index) => {
-          return line ? <p key={index}>{line}</p> : <br />;
+          return line ? <p key={index}>{line}</p> : <br key={index} />;
         })}
       </div>
       <ImageListMaker image={post.image} />

--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -8,8 +8,6 @@ import IconButton from "../../atoms/IconButton/IconButton";
 
 function ImageListMaker({ image }) {
   const imageData = image.split(",");
-  console.dir(imageData);
-  console.log(imageData.length);
   //이미지가 없을 경우 빈 태그 리턴
   if (!image) return <></>;
   else {
@@ -35,7 +33,7 @@ function PostCard({ post }) {
   return (
     <article className={styles["container-post"]}>
       <div className={styles["profile"]}>
-        <ImageBox type={"circle"} size={"medium_small"} />
+        <ImageBox type={"circle"} size={"medium_small"} src={author.image} />
       </div>
       <div className={styles["container-user"]}>
         <Author authorName={author.username} authorId={author.accountname} />


### PR DESCRIPTION
## 작업내용
post의 작성자 이미지 src 정보가 post데이터 받아오면서 함께 가져와지길래 배치했습니당! (초록부분)

아래 현재 계정 이미지(파란부분)는 아직 어디에서 받아와야 하는지 모르겠습니다!!ㅎ_ㅎ

![image](https://user-images.githubusercontent.com/68495264/180157213-8f3481e0-6ea9-4de0-a72e-468f7e2b0dcb.png)

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
