### PR TITLE
Refactor: 로그인, 회원가입의 state 통합 및 함수명 직관적으로 변경

### DIFF
--- a/src/components/modules/ProfileForm/ProfileForm.jsx
+++ b/src/components/modules/ProfileForm/ProfileForm.jsx
@@ -5,18 +5,10 @@ import styles from "./profileForm.module.css";
 
 function ProfileForm({
   setAccountnameValid,
-  image,
-  setImage,
-  username,
-  setUsername,
-  accountname,
-  setAccountname,
-  intro,
-  setIntro,
-  usernameError,
-  setUsernameError,
-  accountnameError,
-  setAccountnameError,
+  value,
+  setValue,
+  error,
+  setError,
   usernameInput,
   accountnameInput,
 }) {
@@ -26,57 +18,67 @@ function ProfileForm({
 
   // 사용자 이름과 계정 ID 내용이 바뀌면 에러가 표시되지 않도록 비웁니다.
   useEffect(() => {
-    setUsernameError("");
-  }, [username]);
+    setError({ ...error, username: "" });
+  }, [value.username]);
 
   useEffect(() => {
-    setAccountnameError("");
+    setError({ ...error, accountname: "" });
     setAccountnameValid(false);
-  }, [accountname]);
+  }, [value.accountname]);
 
   // 이미지를 선택하면 우선 로컬 url로 보여주는 함수입니다.
-  function handleImageInputData(event) {
+  function handleImageValue(event) {
     const file = event.target.files[0];
-    console.log(file);
     if (!file) {
       return;
     }
     const preview = { src: URL.createObjectURL(file), data: file };
-    setImage(preview);
+    setValue({ ...value, image: preview });
   }
 
   // 사용자 이름,계정 ID, 소개 셋 다 input이므로 한꺼번에 관리합니다.
-  function handleEditInputData(event) {
-    // input id가 "username" 이면 사용자 이름 세팅
-    if (event.target.id === "username") {
-      setUsername(event.target.value);
-      // input id가 "accountname" 이면 계정 ID 세팅
-    } else if (event.target.id === "accountname") {
-      setAccountname(event.target.value);
-      // input id가 "intro" 면 소개 세팅
-    } else if (event.target.id === "intro") {
-      setIntro(event.target.value);
-    }
+  function handleInputValue(event) {
+    setValue({ ...value, [event.target.id]: event.target.value });
   }
 
-  // username input이 blur되었을 때 유효성 검사를 실행하는 함수입니다.
-  function handleBlurUsername() {
+  function checkUsernameError() {
     // 사용자 이름 칸이 비어 있는지 검사합니다.
-    if (!username) {
-      setUsernameError("사용자 이름을 입력해 주세요.");
+    if (!value.username) {
+      setError({ ...error, username: "사용자 이름을 입력해 주세요." });
+      return false;
     }
     // 사용자 이름이 2~10자인지 검사합니다.
-    else if (username.length < 2 || username.length > 10) {
-      setUsernameError("사용자 이름은 2~10자 이내여야 합니다.");
+    else if (value.username.length < 2 || value.username.length > 10) {
+      setError({ ...error, username: "사용자 이름은 2~10자 이내여야 합니다." });
+      return false;
     }
+    return true;
+  }
+
+  function checkAccountnameError() {
+    // 계정 ID 칸이 비어 있는지 검사합니다.
+    if (!value.accountname) {
+      setError({ ...error, accountname: "계정 ID를 입력해 주세요." });
+      return false;
+    }
+    // 계정 ID 형식에 맞는지 검사합니다.
+    else if (!value.accountname.match(accountnameRegExp)) {
+      setError({
+        ...error,
+        accountname: "계정 ID는 영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.",
+      });
+      return false;
+    }
+    checkAccountnameValid();
+    return true;
   }
 
   // accountname input이 blur되었을 때 유효성 검사를 실행하는 함수입니다.
-  async function handleBlurAccountname() {
+  async function checkAccountnameValid() {
     // 이미 존재하는 계정 ID인지 검사합니다.
     const reqBody = {
       user: {
-        accountname: accountname,
+        accountname: value.accountname,
       },
     };
     try {
@@ -90,7 +92,7 @@ function ProfileForm({
       const result = await data.json();
 
       if (result.message == "이미 가입된 계정ID 입니다.") {
-        setAccountnameError(result.message);
+        setError({ ...error, accountname: result.message });
       }
       // 가입된 계정 ID가 아니라면 isAccountValid를 true로 바꿉니다.
       else {
@@ -98,16 +100,6 @@ function ProfileForm({
       }
     } catch (error) {
       console.log(error.message);
-    }
-    // 계정 ID 칸이 비어 있는지 검사합니다.
-    if (!accountname) {
-      setAccountnameError("계정 ID를 입력해 주세요.");
-    }
-    // 계정 ID 형식에 맞는지 검사합니다.
-    else if (!accountname.match(accountnameRegExp)) {
-      setAccountnameError(
-        "계정 ID는 영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
-      );
     }
   }
 
@@ -118,21 +110,21 @@ function ProfileForm({
         boxType="circle"
         boxSize="large"
         image={
-          image
-            ? image.src
+          value.image
+            ? value.image.src
             : "https://mandarin.api.weniv.co.kr/1658306906297.png"
         }
-        saveImage={handleImageInputData}
+        saveImage={handleImageValue}
       />
       <InputBox
         id="username"
         name="사용자 이름"
         type="text"
         placeholder="2~10자 이내여야 합니다."
-        value={username}
-        error={usernameError}
-        onBlur={handleBlurUsername}
-        onChange={handleEditInputData}
+        value={value.username}
+        error={error.username}
+        onBlur={checkUsernameError}
+        onChange={handleInputValue}
         innerRef={usernameInput}
       />
       <InputBox
@@ -140,10 +132,10 @@ function ProfileForm({
         name="계정 ID"
         type="text"
         placeholder="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
-        value={accountname}
-        error={accountnameError}
-        onBlur={handleBlurAccountname}
-        onChange={handleEditInputData}
+        value={value.accountname}
+        error={error.accountname}
+        onBlur={checkAccountnameError}
+        onChange={handleInputValue}
         innerRef={accountnameInput}
       />
       <InputBox
@@ -151,8 +143,8 @@ function ProfileForm({
         name="소개"
         type="text"
         placeholder="자신과 판매할 상품에 대해 소개해 주세요!"
-        value={intro}
-        onChange={handleEditInputData}
+        value={value.intro}
+        onChange={handleInputValue}
       />
     </div>
   );

--- a/src/components/organisms/ProfileSetting/ProfileSetting.jsx
+++ b/src/components/organisms/ProfileSetting/ProfileSetting.jsx
@@ -1,18 +1,24 @@
 import React, { useContext, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import imageCompression from "browser-image-compression";
 import ProfileForm from "../../modules/ProfileForm/ProfileForm";
 import Button from "../../atoms/Button/Button";
 import { RegisterContext } from "../../../contexts/RegisterContext";
-import imageCompression from "browser-image-compression";
-import { useNavigate } from "react-router-dom";
 import styles from "./profileSetting.module.css";
 
 function ProfileSetting() {
-  const [image, setImage] = useState("");
-  const [username, setUsername] = useState("");
-  const [accountname, setAccountname] = useState("");
-  const [intro, setIntro] = useState("");
-  const [usernameError, setUsernameError] = useState("");
-  const [accountnameError, setAccountnameError] = useState("");
+  const [value, setValue] = useState({
+    image: "",
+    username: "",
+    accountname: "",
+    intro: "",
+  });
+
+  const [error, setError] = useState({
+    username: "",
+    accountname: "",
+  });
+
   // 계정 ID가 이미 가입되어 있으면 false, 가입 가능하면 true입니다.
   const [isAccountnameValid, setAccountnameValid] = useState(false);
 
@@ -67,21 +73,24 @@ function ProfileSetting() {
     accountnameInput.current.blur();
 
     // 에러가 없고 계정 ID가 유효하다면 context에 이미지, 사용자 이름, 계정 ID, 소개를 저장합니다.
-    if (!usernameError && !accountnameError && isAccountnameValid) {
+    if (!error.username && !error.accountname && isAccountnameValid) {
       const data = registerData;
-      if (image) {
-        const resizedImage = await handleImageResize(image.data);
+      if (value.image) {
+        const resizedImage = await handleImageResize(value.image.data);
         const imageUrl = await uploadImage(resizedImage);
         data.user.image = imageUrl;
-        URL.revokeObjectURL(image.src);
+        URL.revokeObjectURL(value.image.src);
       }
       // 이미지를 선택하지 않았다면 기본 이미지로 설정됩니다.
       else {
         data.user.image = "https://mandarin.api.weniv.co.kr/1658306906297.png";
       }
-      data.user.username = username;
-      data.user.accountname = accountname;
-      data.user.intro = intro;
+      data.user = {
+        ...data.user,
+        username: value.username,
+        accountname: value.accountname,
+        intro: value.intro,
+      };
       setRegisterData(data);
 
       // context에 저장된 데이터로 회원가입을 진행합니다.
@@ -106,25 +115,17 @@ function ProfileSetting() {
       <p className={styles["message"]}>나중에 언제든지 변경할 수 있습니다.</p>
       <ProfileForm
         setAccountnameValid={setAccountnameValid}
-        image={image}
-        setImage={setImage}
-        username={username}
-        setUsername={setUsername}
-        accountname={accountname}
-        setAccountname={setAccountname}
-        intro={intro}
-        setIntro={setIntro}
-        usernameError={usernameError}
-        setUsernameError={setUsernameError}
-        accountnameError={accountnameError}
-        setAccountnameError={setAccountnameError}
+        value={value}
+        setValue={setValue}
+        error={error}
+        setError={setError}
         usernameInput={usernameInput}
         accountnameInput={accountnameInput}
       />
       <Button
         size="large"
         label="게임어스 시작하기"
-        active={username && accountname && true}
+        active={value.username && value.accountname && true}
         primary={true}
         onClick={handleRegister}
       />


### PR DESCRIPTION
## 작업내용
- #4, #12 의 너무 많았던 state 개수를 줄이고, 함수명을 직관적으로 변경했습니다.
## 레퍼런스
- https://jeonghwan-kim.github.io/dev/2022/03/29/react-form-and-formik.html
## 중점적으로 봐주었으면 하는 부분
- value와 error 두 개의 state를 선언하고 기존 state들을 객체화해서 합쳤습니다.
- 값을 가져올 땐 `value.email` 처럼 접근합니다.
- 값을 설정할 땐 `setValue({...value, email: "..."})` 식으로 전개 구문을 통해 부분 업데이트가 가능합니다.
- 기능은 제대로 작동하는 거 같은데 혹시 에러나는 부분이 있다면 이슈 등록해 주세요!
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
