### PR TITLE
Design: 프로필 페이지의 버튼 css 수정 및 마크업 수정

### DIFF
--- a/src/components/modules/MyProfileButton/myProfileButton.module.css
+++ b/src/components/modules/MyProfileButton/myProfileButton.module.css
@@ -2,7 +2,6 @@
   display: flex;
   gap: 12px;
   justify-content: center;
-  margin: 0 91px;
 }
 
 .container-button > a:first-child {

--- a/src/components/modules/UserProfileBox/userProfileBox.module.css
+++ b/src/components/modules/UserProfileBox/userProfileBox.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin: 30px auto 24px;
+  margin-bottom: 24px;
 }
 
 .wrapper-upper {

--- a/src/components/organisms/ProductList/ProductList.jsx
+++ b/src/components/organisms/ProductList/ProductList.jsx
@@ -4,7 +4,7 @@ import styles from "./productList.module.css";
 
 function ProductList({ products }) {
   return (
-    <div className={styles["wrapper-products"]}>
+    <section className={styles["wrapper-products"]}>
       <h2 className={styles["title"]}>판매 중인 상품</h2>
       {products.data > 0 ? (
         <ul className={styles["list-product"]}>
@@ -24,7 +24,7 @@ function ProductList({ products }) {
       ) : (
         <p className={styles["message"]}>판매 중인 상품이 없어요.</p>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -2,11 +2,12 @@ import React from "react";
 import UserProfileBox from "../../modules/UserProfileBox/UserProfileBox";
 import MyProfileButton from "../../modules/MyProfileButton/MyProfileButton";
 import ProfileButton from "../../modules/ProfileButton/ProfileButton";
+import styles from "./userProfile.module.css";
 
 function UserProfile({ userProfile }) {
   const myAccountname = window.localStorage.getItem("accountname");
   return (
-    <div>
+    <section className={styles["wrapper-profile"]}>
       <UserProfileBox
         src={userProfile.image}
         userName={userProfile.username}
@@ -20,7 +21,7 @@ function UserProfile({ userProfile }) {
       ) : (
         <ProfileButton isFollowing={userProfile.isFollowing} />
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/components/organisms/UserProfile/userProfile.module.css
+++ b/src/components/organisms/UserProfile/userProfile.module.css
@@ -1,0 +1,3 @@
+.wrapper-profile {
+  padding: 30px 0 26px;
+}


### PR DESCRIPTION
## 작업내용
- #11 에서 화면 너비가 좁아졌을 때 버튼이 줄어드는 이슈 #91 을 수정하였습니다.
- #11 에서 프로필 컴포넌트와 판매중인 상품 컴포넌트의 태그를 `<div>` 대신 `<section>`으로 변경하였습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
-  기존 제 화면에선 차이가 없어서 잘 몰랐는데 좌우 마진을 고정값으로 줘서 생겼던 문제 같습니다. @yeodahui 님 테스트 부탁드려요!
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
