### PR TITLE
Feat: 팔로우 버튼을 클릭하면 팔로우/언팔로우로 바뀌도록 구현

### DIFF
--- a/src/components/modules/ProfileButton/ProfileButton.jsx
+++ b/src/components/modules/ProfileButton/ProfileButton.jsx
@@ -1,18 +1,20 @@
-import React from "react";
+import React, { useState } from "react";
 import Button from "../../atoms/Button/Button";
 import IconButton from "../../atoms/IconButton/IconButton";
 import styles from "./profileButton.module.css";
 
-function ProfileButton({ isFollowing }) {
+function ProfileButton() {
+  const [isFollowing, setIsFollowing] = useState(false);
+
   return (
     <div className={styles["container-button"]}>
       <IconButton type="message" text="메시지 보내기" />
       <Button
-        href="#"
         size="medium"
         label={isFollowing ? "언팔로우" : "팔로우"}
         active={true}
         primary={isFollowing ? false : true}
+        onClick={() => setIsFollowing(!isFollowing)}
       />
       <IconButton type="share" text="공유하기" />
     </div>

--- a/src/components/modules/ProfileButton/profileButton.module.css
+++ b/src/components/modules/ProfileButton/profileButton.module.css
@@ -2,9 +2,8 @@
   display: flex;
   gap: 10px;
   justify-content: center;
-  margin: 0 84px;
 }
 
-.container-button > a {
+.container-button > button:nth-child(2) {
   width: 120px;
 }


### PR DESCRIPTION
## 작업내용
- #11 에서 타인의 프로필 페이지의 팔로우 버튼을 누르면 언팔로우로, 다시 누르면 팔로우로 바뀌게끔 했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 실제 팔로우 기능은 도전과제라 아직 구현하지 않았습니다.
- gif 찍는 프로그램이 없어서 못 보여드리는데, 버튼이 팔로우->언팔로우, 언팔로우->팔로우 로 바뀌면서 밑에 있는 판매중인 상품 컴포넌트가 살짝씩 위아래로 움직입니다? 왜이러는지 원인을 모르겠어요 추후에 확인 부탁드립니다..
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
