### PR TITLE
Feat: 하단 탭 메뉴 구현

### DIFF
--- a/src/components/atoms/NavItem/NavItem.jsx
+++ b/src/components/atoms/NavItem/NavItem.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import styles from "./navItem.module.css";
+
+function NavItem({link, label, icon}) {
+  const active = true;
+  return (
+      <Link to={link} className={`${styles.link} ${styles[icon]} ${active ? styles.active : null}`}>
+        <span>{label}</span>
+      </Link>
+  )
+}
+
+export default NavItem;

--- a/src/components/atoms/NavItem/navItem.module.css
+++ b/src/components/atoms/NavItem/navItem.module.css
@@ -1,0 +1,39 @@
+.link::before {
+  content: " ";
+  display: block;
+  margin: 0 auto 4px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  width: 24px;
+  height: 24px;
+}
+
+.active {
+  color: #F26E22;
+}
+
+.home::before {
+  background-image: url("../../../assets/icon-home.svg");
+}
+.home.active::before {
+  background-image: url("../../../assets/icon-home-fill.svg");
+}
+
+.chat::before {
+  background-image: url("../../../assets/icon-message-circle.svg");
+}
+.chat.active::before {
+  background-image: url("../../../assets/icon-message-circle-fill.svg");
+}
+
+.post::before {
+  background-image: url("../../../assets/icon-edit.svg");
+}
+
+.profile::before {
+  background-image: url("../../../assets/icon-user.svg");
+}
+.profile.active::before {
+  background-image: url("../../../assets/icon-user-fill.svg");
+}

--- a/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
+++ b/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
@@ -1,21 +1,22 @@
-import { Link } from "react-router-dom";
+import NavItem from "../../atoms/NavItem/NavItem";
 import styles from "./bottomNavigateBar.module.css";
 
 function BottomBar() {
+  const user = "jordi3";
   return (
     <nav className={styles["nav"]}>
       <ul className={styles["list-nav"]}>
         <li className={`${styles["item-nav"]} ${styles["home"]}`}>
-          <Link to={"/"}>홈</Link>
+          <NavItem link={"/"} label={"홈"} icon={"home"}/>
         </li>
         <li className={`${styles["item-nav"]} ${styles["chat"]}`}>
-          <Link to={"/chat"}>채팅</Link>
+          <NavItem link={"/chat"} label={"채팅"} icon={"chat"}/>
         </li>
         <li className={`${styles["item-nav"]} ${styles["post"]}`}>
-          <Link to={"/post"}>게시물 작성</Link>
+          <NavItem link={"/post"} label={"게시물 작성"} icon={"post"}/>
         </li>
         <li className={`${styles["item-nav"]} ${styles["profile"]}`}>
-          <Link to={"/profile"}>프로필</Link>
+          <NavItem link={`/profile/${user}`} label={"프로필"} icon={"profile"}/>
         </li>
       </ul>
     </nav>

--- a/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
+++ b/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+import styles from "./bottomNavigateBar.module.css";
+
+function BottomBar() {
+  return (
+    <nav className={styles["nav"]}>
+      <ul className={styles["list-nav"]}>
+        <li className={`${styles["item-nav"]} ${styles["home"]}`}>
+          <Link to={"/"}>홈</Link>
+        </li>
+        <li className={`${styles["item-nav"]} ${styles["chat"]}`}>
+          <Link to={"/chat"}>채팅</Link>
+        </li>
+        <li className={`${styles["item-nav"]} ${styles["post"]}`}>
+          <Link to={"/post"}>게시물 작성</Link>
+        </li>
+        <li className={`${styles["item-nav"]} ${styles["profile"]}`}>
+          <Link to={"/profile"}>프로필</Link>
+        </li>
+      </ul>
+    </nav>
+  )
+}
+
+export default BottomBar;

--- a/src/components/modules/BottomNavigateBar/bottomNavigateBar.module.css
+++ b/src/components/modules/BottomNavigateBar/bottomNavigateBar.module.css
@@ -3,15 +3,20 @@
   bottom: 0;
   left: 0;
   right: 0;
-}
-
-.list-nav {
   background-color: #fff;
   border-top: 1px solid var(--lightgray-color);
 }
 
+.list-nav {
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-around;
+  max-width: 700px;
+}
+
 .item-nav {
-  display: inline-block;
+  flex-wrap: nowrap;
+  width: 84px;
   padding: 12px 30px 6px;
   font-weight: 400;
   line-height: 14px;

--- a/src/components/modules/BottomNavigateBar/bottomNavigateBar.module.css
+++ b/src/components/modules/BottomNavigateBar/bottomNavigateBar.module.css
@@ -1,0 +1,25 @@
+.nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.list-nav {
+  background-color: #fff;
+  border-top: 1px solid var(--lightgray-color);
+}
+
+.item-nav {
+  display: inline-block;
+  padding: 12px 30px 6px;
+  font-weight: 400;
+  line-height: 14px;
+  letter-spacing: 0em;
+  text-align: center;
+  color: var(--darkgray-color);
+}
+
+.item-nav:not(:last-of-type) {
+  margin-right: auto;
+}

--- a/src/pages/ChatListPage/ChatListPage.jsx
+++ b/src/pages/ChatListPage/ChatListPage.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ImageBox from "../../components/atoms/ImageBox/ImageBox";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
+import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
 import styles from "./chatListPage.module.css";
 
 function ChatListPage() {
@@ -46,7 +47,7 @@ function ChatListPage() {
           </li>
         ))}
       </ul>
-      
+      <BottomNavigateBar />
     </section>
   )
 }

--- a/src/pages/ChatListPage/ChatListPage.jsx
+++ b/src/pages/ChatListPage/ChatListPage.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ImageBox from "../../components/atoms/ImageBox/ImageBox";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
-import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 import styles from "./chatListPage.module.css";
 
 function ChatListPage() {

--- a/src/pages/FollowerPage.jsx
+++ b/src/pages/FollowerPage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
-import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../components/organisms/FollowList/FollowList";
 
 function FollowerPage() {

--- a/src/pages/FollowerPage.jsx
+++ b/src/pages/FollowerPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
+import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../components/organisms/FollowList/FollowList";
 
 function FollowerPage() {
@@ -32,7 +33,7 @@ function FollowerPage() {
   }, [accountname]);
 
   return (
-    <>
+    <section>
       <h1 className="a11y-hidden">팔로워 페이지</h1>
       <HeaderForm
         backButton={true}
@@ -41,7 +42,8 @@ function FollowerPage() {
         menuButton={false}
       />
       {followers && <FollowList list={followers} />}
-    </>
+      <BottomNavigateBar />
+    </section>
   );
 }
 

--- a/src/pages/FollowingPage.jsx
+++ b/src/pages/FollowingPage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
-import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../components/organisms/FollowList/FollowList";
 
 function FollowingPage() {

--- a/src/pages/FollowingPage.jsx
+++ b/src/pages/FollowingPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
+import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../components/organisms/FollowList/FollowList";
 
 function FollowingPage() {
@@ -35,7 +36,7 @@ function FollowingPage() {
   }, [accountname]);
 
   return (
-    <>
+    <section>
       <h1 className="a11y-hidden">팔로잉 페이지</h1>
       <HeaderForm
         backButton={true}
@@ -44,7 +45,8 @@ function FollowingPage() {
         menuButton={false}
       />
       {followings && <FollowList list={followings} />}
-    </>
+      <BottomNavigateBar />
+    </section>
   );
 }
 

--- a/src/pages/FollowingPage.jsx
+++ b/src/pages/FollowingPage.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
-import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../components/organisms/FollowList/FollowList";
 
 function FollowingPage() {

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -3,6 +3,7 @@ import Button from "../../components/atoms/Button/Button";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import PostCard from "../../components/modules/PostCard/PostCard";
 import catImageURL from "../../assets/icon-404-cat.png";
+import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
 import styles from "./homePage.module.css";
 
 function HomePage() {
@@ -77,6 +78,7 @@ function HomePage() {
           ))}
         </ul>
       )}
+      <BottomNavigateBar />
     </section>
   );
 }

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -3,7 +3,7 @@ import Button from "../../components/atoms/Button/Button";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import PostCard from "../../components/modules/PostCard/PostCard";
 import catImageURL from "../../assets/icon-404-cat.png";
-import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 import styles from "./homePage.module.css";
 
 function HomePage() {

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
 import UserProfile from "../components/organisms/UserProfile/UserProfile";
 import ProductList from "../components/organisms/ProductList/ProductList";
+import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
 
 function ProfilePage() {
   // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.
@@ -56,12 +57,13 @@ function ProfilePage() {
   }, [accountname]);
 
   return (
-    <>
+    <section>
       <h1 className="a11y-hidden">프로필 페이지</h1>
       <HeaderForm backButton={true} menuButton={true} />
       <UserProfile userProfile={profile} />
       <ProductList products={products} />
-    </>
+      <BottomNavigateBar />
+    </section>
   );
 }
 

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
 import UserProfile from "../components/organisms/UserProfile/UserProfile";
 import ProductList from "../components/organisms/ProductList/ProductList";
-import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 
 function ProfilePage() {
   // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import HeaderForm from "../components/modules/HeaderForm/HeaderForm";
 import UserProfile from "../components/organisms/UserProfile/UserProfile";
 import ProductList from "../components/organisms/ProductList/ProductList";
-import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../components/modules/BottomNavigateBar/BottomNavigateBar";
 
 function ProfilePage() {
   // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -1,13 +1,15 @@
+import { Link } from "react-router-dom";
+import styles from "./searchPage.module.css";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import ImageBox from "../../components/atoms/ImageBox/ImageBox";
-import styles from "./searchPage.module.css";
-import { Link } from "react-router-dom";
+import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
 
 // 마크업까지 구현되었으며, 추후 props를 통해 검색 기능을 추가할 예정
 
 function SearchPage() {
   return (
-    <>
+    <section>
+      <h1 className="a11y-hidden">유저 검색</h1>
       <HeaderForm backButton={true} input={true} />
       <ul className={styles["container-users"]}>
         <li>
@@ -39,8 +41,9 @@ function SearchPage() {
           </Link>
         </li>
       </ul>
-    </>
+      <BottomNavigateBar />
+    </section>
   )
 }
 
-export default SearchPage
+export default SearchPage;

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import styles from "./searchPage.module.css";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import ImageBox from "../../components/atoms/ImageBox/ImageBox";
-import BottomNavigateBar from "./components/modules/BottomNavigateBar/BottomNavigateBar";
+import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 
 // 마크업까지 구현되었으며, 추후 props를 통해 검색 기능을 추가할 예정
 


### PR DESCRIPTION
## 작업내용
#2 하단바를 추가하였습니다.
- 하단 네비게이션 바 컴포넌트
- 네비게이션 아이템 컴포넌트
![하단바 실행화면](https://user-images.githubusercontent.com/102221305/180599641-ebb28e2d-f8bc-43a1-b012-39361519c7c6.gif)

## 중점적으로 봐주었으면 하는 부분
현재 페이지에 따라 하이라이트 되는 기능이 미완성입니다.
contextAPI를 통해 accountname과 현재 페이지를 추적하려고 하는데, 메인 브랜치에 push된 코드들을 꺼내오고싶어 중간 PR 날립니다!

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
