### PR TITLE
Fix: 게시글에서 유저 영역 클릭 시 이동하는 링크 수정

### DIFF
--- a/src/components/atoms/Author/Author.jsx
+++ b/src/components/atoms/Author/Author.jsx
@@ -4,7 +4,7 @@ import styles from "./author.module.css";
 
 function Author({authorName, authorId}) {
   return (
-    <Link to={authorId}>
+    <Link to={`/profile/${authorId}`}>
       <span className={styles["text-name"]}>{authorName}</span>
       <span className={styles["text-id"]} >@{authorId}</span>
     </Link>

--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -5,6 +5,7 @@ import InfoIconGroup from "../InfoIconGroup/InfoIconGroup";
 import PostDate from "../../atoms/PostDate/PostDate";
 import styles from "./postCard.module.css";
 import IconButton from "../../atoms/IconButton/IconButton";
+import { Link } from "react-router-dom";
 
 function ImageListMaker({ image }) {
   const imageData = image.split(",");
@@ -32,9 +33,9 @@ function PostCard({ post }) {
 
   return (
     <article className={styles["container-post"]}>
-      <div className={styles["profile"]}>
+      <Link to={`/profile/${author.accountname}`} className={styles["profile"]}>
         <ImageBox type={"circle"} size={"medium_small"} src={author.image} />
-      </div>
+      </Link>
       <div className={styles["container-user"]}>
         <Author authorName={author.username} authorId={author.accountname} />
         <IconButton type={"more"} text={"더보기"} onClick={() => {}} />


### PR DESCRIPTION
## 작업내용
게시글 컴포넌트에서 유저 프로필 사진 영역을 클릭하면 이동이 없었고, 닉네임, 아이디를 클릭하면 `/profile/:accountname`이 아닌 `/:accountname`으로 이동되었던 것을 올바른 경로로 이동하게 만들었습니다.
![링크 수정](https://user-images.githubusercontent.com/102221305/180600703-f135aef4-5261-4f91-833b-9cd821729f7b.gif)

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
