### PR TITLE
Fix: 게시글 업로드 시 이미지가 없어도 버튼 활성화되게 수정

### DIFF
--- a/src/pages/UploadPage/UploadAPI.js
+++ b/src/pages/UploadPage/UploadAPI.js
@@ -3,9 +3,11 @@ const TOKEN = window.localStorage.getItem("token");
 
 async function uploadData(imageNames, text) {
   const imageData = imageNames
-    .split(",")
-    .map((name) => BASE_URL + "/" + name)
-    .join(",");
+    ? imageNames
+        .split(",")
+        .map((name) => BASE_URL + "/" + name)
+        .join(",")
+    : "";
   const data = {
     post: {
       content: text,

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -80,7 +80,7 @@ function UploadPage() {
         backButton={true}
         button="업로드"
         onClick={handleUploadButton}
-        active={text && images.length > 0 && true}
+        active={text && true}
       />
       <UploadForm
         images={images}


### PR DESCRIPTION
## 작업내용
- #10 에서 이미지가 있어야 활성화되던 업로드 버튼을 이미지 없이 텍스트만 있어도 활성화되도록 변경했습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
