### PR TITLE
Refactor: 이미지 업로드 함수 중복 코드 제거

### DIFF
--- a/src/common/ImageUpload.js
+++ b/src/common/ImageUpload.js
@@ -1,28 +1,11 @@
 const BASE_URL = "https://mandarin.api.weniv.co.kr";
 
-//이미지 업로드
-async function uploadImage(file) {
+//이미지 업로드 - 한 개, 여러개
+async function uploadImage(files) {
+  const fileArr = Array.isArray(files) ? [...files] : [files];
+  let fileUrls = [];
   try {
-    const formData = new FormData();
-    formData.append("image", file);
-    const imageReqPath = "/image/uploadfile";
-    const res = await fetch(BASE_URL + imageReqPath, {
-      method: "POST",
-      body: formData,
-    });
-    const json = await res.json();
-    const filename = await json.filename;
-    return BASE_URL + "/" + filename;
-  } catch (error) {
-    console.log(error.message);
-  }
-}
-
-//여러장 이미지 업로드
-async function uploadmultipleImages(files) {
-  let fileNames = [];
-  try {
-    for (let file of files) {
+    for (let file of fileArr) {
       const formData = new FormData();
       formData.append("image", file);
       const res = await fetch(BASE_URL + "/image/uploadfile", {
@@ -30,17 +13,16 @@ async function uploadmultipleImages(files) {
         body: formData,
       });
       const json = await res.json();
-      const filename = await json.filename;
-      fileNames.push(filename);
+      fileUrls.push(`${BASE_URL}/${json.filename}`);
     }
-    if (fileNames.length > 1) {
-      return fileNames.join(",");
+    if (fileUrls.length > 1) {
+      return fileUrls.join(",");
     } else {
-      return fileNames[0];
+      return fileUrls[0];
     }
   } catch (error) {
     console.log(error.message);
   }
 }
 
-export { uploadImage, uploadmultipleImages };
+export { uploadImage };

--- a/src/pages/UploadPage/UploadAPI.js
+++ b/src/pages/UploadPage/UploadAPI.js
@@ -2,12 +2,7 @@ const BASE_URL = "https://mandarin.api.weniv.co.kr";
 const TOKEN = window.localStorage.getItem("token");
 
 async function uploadData(imageNames, text) {
-  const imageData = imageNames
-    ? imageNames
-        .split(",")
-        .map((name) => BASE_URL + "/" + name)
-        .join(",")
-    : "";
+  const imageData = imageNames ? imageNames : "";
   const data = {
     post: {
       content: text,

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { handleImageSize } from "../../common/ImageResize";
-import { uploadmultipleImages } from "../../common/ImageUpload";
+import { uploadImage } from "../../common/ImageUpload";
 import { uploadData } from "./UploadAPI";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import ImageInputButton from "../../components/atoms/ImageInputButton/ImageInputButton";
@@ -26,7 +26,6 @@ function UploadPage() {
   //이미지 프리뷰
   function previewMultipleImages(files) {
     const copyImages = [...images];
-    console.log(files);
     for (let i = 0; i < files.length; i++) {
       const image = {
         key: Date.now() + i,
@@ -57,7 +56,7 @@ function UploadPage() {
     for (let file of images) {
       imageArr.push(await handleImageSize(file.data));
     }
-    return await uploadmultipleImages(imageArr);
+    return await uploadImage(imageArr);
   }
 
   //업로드 버튼


### PR DESCRIPTION
## 작업내용
- 여러 이미지 업로드와 한개 이미지 업로드 API 코드 중복되는 부분이 많아서 하나로 합쳤습니다. 
- 여러 이미지 업로드를 할 경우에도 filename이 아닌 url을 리턴하도록 하여 코드를 줄였습니다. 

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
