### PR TITLE
Fix: 하단바 프로필 클릭 시 로컬에 저장된 accountname의 프로필로 이동

### DIFF
--- a/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
+++ b/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
@@ -2,7 +2,7 @@ import NavItem from "../../atoms/NavItem/NavItem";
 import styles from "./bottomNavigateBar.module.css";
 
 function BottomNavigateBar() {
-  const user = "jordi3";
+  const accountname = localStorage.getItem("accountname");
   return (
     <nav className={styles["nav"]}>
       <ul className={styles["list-nav"]}>
@@ -17,7 +17,7 @@ function BottomNavigateBar() {
         </li>
         <li className={`${styles["item-nav"]} ${styles["profile"]}`}>
           <NavItem
-            link={`/profile/${user}`}
+            link={`/profile/${accountname}`}
             label={"프로필"}
             icon={"profile"}
           />


### PR DESCRIPTION
## 작업내용
#2 하단 탭에서 프로필을 클릭할 경우 jordi3 유저의 프로필 페이지로만 이동하던 것을, 로컬 스토리지에 저장된 accountname을 불러와 이동하도록 만들었습니다.

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
