### PR TITLE
Feat: 나의 프로필 페이지에서 상품 누르면 모달 뜨는 기능 추가

### DIFF
--- a/src/components/modules/Product/Product.jsx
+++ b/src/components/modules/Product/Product.jsx
@@ -3,16 +3,14 @@ import React from "react";
 import ImageBox from "../../atoms/ImageBox/ImageBox";
 import styles from "./product.module.css";
 
-function Product({ link, itemImage, itemName, price }) {
+function Product({ product }) {
   return (
     <div className={styles["wrapper-product"]}>
-      <a href={link}>
-        <ImageBox type="rounded_square" size="small" src={itemImage} alt="" />
-        <span className={styles["product_name"]}>{itemName}</span>
-        <strong className={styles["product_price"]}>
-          {price.toLocaleString("en-US")}원
-        </strong>
-      </a>
+      <ImageBox type="rounded_square" size="small" src={product.itemImage} alt="" />
+      <span className={styles["product_name"]}>{product.itemName}</span>
+      <strong className={styles["product_price"]}>
+        {product.price.toLocaleString("en-US")}원
+      </strong>
     </div>
   );
 }

--- a/src/components/organisms/ProductList/ProductList.jsx
+++ b/src/components/organisms/ProductList/ProductList.jsx
@@ -7,6 +7,14 @@ function ProductList({ isMyProfile, products }) {
   const [onModal, setOnModal] = useState(false);
   const [link, setLink] = useState("");
 
+  function handleDeletePost() {
+    // 상품 게시글 삭제 함수입니다.
+  }
+
+  function handleEditPost() {
+    // 상품 게시글 수정 함수입니다.
+  }
+
   function navigateLink(link) {
     window.open(link, "_blank");
   }
@@ -44,8 +52,8 @@ function ProductList({ isMyProfile, products }) {
         <Modal
           onClose={() => setOnModal(false)}
           buttons={[
-            { text: "삭제", onClick: () => {} },
-            { text: "수정", onClick: () => {} },
+            { text: "삭제", onClick: handleDeletePost },
+            { text: "수정", onClick: handleEditPost },
             {
               text: "웹사이트에서 상품 보기",
               onClick: () => navigateLink(link),

--- a/src/components/organisms/ProductList/ProductList.jsx
+++ b/src/components/organisms/ProductList/ProductList.jsx
@@ -1,30 +1,60 @@
-import React from "react";
+import React, { useState } from "react";
 import Product from "../../modules/Product/Product";
 import styles from "./productList.module.css";
+import Modal from "../Modal/Modal";
 
-function ProductList({ products }) {
+function ProductList({ isMyProfile, products }) {
+  const [onModal, setOnModal] = useState(false);
+  const [link, setLink] = useState("");
+
+  function navigateLink(link) {
+    window.open(link, "_blank");
+  }
+
   return (
-    <section className={styles["wrapper-products"]}>
-      <h2 className={styles["title"]}>판매 중인 상품</h2>
-      {products.data > 0 ? (
-        <ul className={styles["list-product"]}>
-          {products.product.map((product, index) => {
-            return (
-              <li key={index}>
-                <Product
-                  link={product.link}
-                  itemImage={product.itemImage}
-                  itemName={product.itemName}
-                  price={product.price}
-                />
-              </li>
-            );
-          })}
-        </ul>
-      ) : (
-        <p className={styles["message"]}>판매 중인 상품이 없어요.</p>
+    <>
+      <section className={styles["wrapper-products"]}>
+        <h2 className={styles["title"]}>판매 중인 상품</h2>
+        {products.data > 0 ? (
+          <ul className={styles["list-product"]}>
+            {products.product.map((product, index) => {
+              return (
+                <li
+                  key={index}
+                  onClick={() => {
+                    if (isMyProfile) {
+                      setLink(product.link);
+                      setOnModal(!onModal);
+                    } else {
+                      navigateLink(product.link);
+                    }
+                  }}
+                >
+                  <Product product={product} />
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className={styles["message"]}>판매 중인 상품이 없어요.</p>
+        )}
+      </section>
+
+      {onModal && (
+        <Modal
+          onClose={() => setOnModal(false)}
+          buttons={[
+            { text: "삭제", onClick: () => {} },
+            { text: "수정", onClick: () => {} },
+            {
+              text: "웹사이트에서 상품 보기",
+              onClick: () => navigateLink(link),
+            },
+          ]}
+          name="상품 게시글"
+        />
       )}
-    </section>
+    </>
   );
 }
 

--- a/src/components/organisms/ProductList/productList.module.css
+++ b/src/components/organisms/ProductList/productList.module.css
@@ -19,6 +19,10 @@
   padding-bottom: 10px;
 }
 
+.list-product li {
+  cursor: pointer;
+}
+
 .message {
   height: 160px;
   line-height: 160px;

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -4,8 +4,7 @@ import MyProfileButton from "../../modules/MyProfileButton/MyProfileButton";
 import ProfileButton from "../../modules/ProfileButton/ProfileButton";
 import styles from "./userProfile.module.css";
 
-function UserProfile({ userProfile }) {
-  const myAccountname = window.localStorage.getItem("accountname");
+function UserProfile({ isMyProfile, userProfile }) {
   return (
     <section className={styles["wrapper-profile"]}>
       <UserProfileBox
@@ -16,7 +15,7 @@ function UserProfile({ userProfile }) {
         followerCount={userProfile.followerCount}
         followingCount={userProfile.followingCount}
       />
-      {userProfile.accountname == myAccountname ? (
+      {isMyProfile ? (
         <MyProfileButton />
       ) : (
         <ProfileButton isFollowing={userProfile.isFollowing} />

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -17,12 +17,19 @@ function ProfilePage() {
   const [products, setProducts] = useState([]);
   const [posts, setPosts] = useState([]);
   const [isAlbum, setAlbum] = useState(false);
+  const [isMyProfile, setIsMyProfile] = useState("");
 
   const BASE_URL = "https://mandarin.api.weniv.co.kr";
   const TOKEN = window.localStorage.getItem("token");
+  const myAccountname = window.localStorage.getItem("accountname");
 
   useEffect(() => {
     // 사용자의 프로필 정보를 받아오는 함수입니다.
+    if (myAccountname === accountname) {
+      setIsMyProfile(true);
+    } else {
+      setIsMyProfile(false);
+    }
     async function getProfile() {
       try {
         const data = await fetch(BASE_URL + `/profile/${accountname}`, {
@@ -80,8 +87,8 @@ function ProfilePage() {
     <>
       <h1 className="a11y-hidden">프로필 페이지</h1>
       <HeaderForm backButton={true} menuButton={true} />
-      <UserProfile userProfile={profile} />
-      <ProductList products={products} />
+      <UserProfile isMyProfile={isMyProfile} userProfile={profile} />
+      <ProductList isMyProfile={isMyProfile} products={products} />
       {posts.length != 0 && (
         <section>
           <PostHeader isAlbum={isAlbum} setAlbum={setAlbum} />


### PR DESCRIPTION
## 작업내용
- #11 에서 내 프로필 페이지일 경우, 판매중인 상품 목록에서 상품을 누르면 모달이 뜨도록 하였습니다. 웹사이트에서 상품 보기를 누르면 상품의 링크로 이동합니다.
![image](https://user-images.githubusercontent.com/79434205/180713415-5ac542d6-9d84-416b-bb9c-6daf1d5da285.png)

- 내 프로필 페이지가 아니라면 바로 상품의 링크로 이동합니다.
## 레퍼런스
- [리액트로 외부 링크 띄우기](https://jaimemin.tistory.com/1449)
## 중점적으로 봐주었으면 하는 부분
- 모달 삭제, 수정 `onclick` 부분에 `() => {}` 로 해놨는데... 괜찮을까요?
- 다른 내용이지만 내 프로필인지 검사하는 걸 useState 이용하고 fetch보다 위에 두었더니 버튼 로딩이 좀 짧아진 거 같아요?
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
