### PR TITLE
Feat: ContextAPI 사용하여 현재 탭에 하이라이팅

### DIFF
--- a/src/components/atoms/NavItem/NavItem.jsx
+++ b/src/components/atoms/NavItem/NavItem.jsx
@@ -1,11 +1,25 @@
-import React from "react";
+import React, { useContext } from "react";
+import { curruntPageContext } from "../../../contexts/curruntPageContext";
 import { Link } from "react-router-dom";
 import styles from "./navItem.module.css";
 
 function NavItem({link, label, icon}) {
-  const active = true;
+  // 현재 보고있는 탭에 하이라이팅
+  const { location } = useContext(curruntPageContext);
+  const { setLocation } = useContext(curruntPageContext);
+
+  let active = false;
+
+  if (location === icon) {
+    active = true;
+  }
+
   return (
-      <Link to={link} className={`${styles.link} ${styles[icon]} ${active ? styles.active : null}`}>
+      <Link 
+        to={link} 
+        onClick={setLocation(icon)}
+        className={`${styles.link} ${styles[icon]} ${active ? styles.active : null}`}
+      >
         <span>{label}</span>
       </Link>
   )

--- a/src/components/atoms/NavItem/NavItem.jsx
+++ b/src/components/atoms/NavItem/NavItem.jsx
@@ -1,7 +1,8 @@
 import { Link } from "react-router-dom";
 import styles from "./navItem.module.css";
 
-function NavItem({link, label, icon}) { 
+function NavItem({link, label, icon}) {
+  // 현재 path가 props로 받아온 링크와 일치하면 currunt는 true
   const currunt = location.pathname === link;
 
   return (

--- a/src/components/atoms/NavItem/NavItem.jsx
+++ b/src/components/atoms/NavItem/NavItem.jsx
@@ -1,24 +1,13 @@
-import React, { useContext } from "react";
-import { curruntPageContext } from "../../../contexts/curruntPageContext";
 import { Link } from "react-router-dom";
 import styles from "./navItem.module.css";
 
-function NavItem({link, label, icon}) {
-  // 현재 보고있는 탭에 하이라이팅
-  const { location } = useContext(curruntPageContext);
-  const { setLocation } = useContext(curruntPageContext);
-
-  let active = false;
-
-  if (location === icon) {
-    active = true;
-  }
+function NavItem({link, label, icon}) { 
+  const currunt = location.pathname === link;
 
   return (
       <Link 
         to={link} 
-        onClick={setLocation(icon)}
-        className={`${styles.link} ${styles[icon]} ${active ? styles.active : null}`}
+        className={`${styles.link} ${styles[icon]} ${currunt ? styles.active : null}`}
       >
         <span>{label}</span>
       </Link>

--- a/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
+++ b/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
@@ -1,28 +1,34 @@
+import { useState } from "react";
+import { curruntPageContext } from "../../../contexts/curruntPageContext";
 import NavItem from "../../atoms/NavItem/NavItem";
 import styles from "./bottomNavigateBar.module.css";
 
 function BottomNavigateBar() {
   const accountname = localStorage.getItem("accountname");
+  const [ location, setLocation ] = useState("home");
+
   return (
     <nav className={styles["nav"]}>
-      <ul className={styles["list-nav"]}>
-        <li className={`${styles["item-nav"]} ${styles["home"]}`}>
-          <NavItem link={"/"} label={"홈"} icon={"home"} />
-        </li>
-        <li className={`${styles["item-nav"]} ${styles["chat"]}`}>
-          <NavItem link={"/chat"} label={"채팅"} icon={"chat"} />
-        </li>
-        <li className={`${styles["item-nav"]} ${styles["post"]}`}>
-          <NavItem link={"/post"} label={"게시물 작성"} icon={"post"} />
-        </li>
-        <li className={`${styles["item-nav"]} ${styles["profile"]}`}>
-          <NavItem
-            link={`/profile/${accountname}`}
-            label={"프로필"}
-            icon={"profile"}
-          />
-        </li>
-      </ul>
+      <curruntPageContext.Provider value={{location, setLocation}}>
+        <ul className={styles["list-nav"]}>
+          <li className={`${styles["item-nav"]} ${styles["home"]}`}>
+            <NavItem link={"/"} label={"홈"} icon={"home"} />
+          </li>
+          <li className={`${styles["item-nav"]} ${styles["chat"]}`}>
+            <NavItem link={"/chat"} label={"채팅"} icon={"chat"} />
+          </li>
+          <li className={`${styles["item-nav"]} ${styles["post"]}`}>
+            <NavItem link={"/post"} label={"게시물 작성"} icon={"post"} />
+          </li>
+          <li className={`${styles["item-nav"]} ${styles["profile"]}`}>
+            <NavItem
+              link={`/profile/${accountname}`}
+              label={"프로필"}
+              icon={"profile"}
+            />
+          </li>
+        </ul>
+      </curruntPageContext.Provider>
     </nav>
   );
 }

--- a/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
+++ b/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
@@ -1,34 +1,29 @@
-import { useState } from "react";
-import { curruntPageContext } from "../../../contexts/curruntPageContext";
 import NavItem from "../../atoms/NavItem/NavItem";
 import styles from "./bottomNavigateBar.module.css";
 
 function BottomNavigateBar() {
   const accountname = localStorage.getItem("accountname");
-  const [ location, setLocation ] = useState("home");
 
   return (
     <nav className={styles["nav"]}>
-      <curruntPageContext.Provider value={{location, setLocation}}>
-        <ul className={styles["list-nav"]}>
-          <li className={`${styles["item-nav"]} ${styles["home"]}`}>
-            <NavItem link={"/"} label={"홈"} icon={"home"} />
-          </li>
-          <li className={`${styles["item-nav"]} ${styles["chat"]}`}>
-            <NavItem link={"/chat"} label={"채팅"} icon={"chat"} />
-          </li>
-          <li className={`${styles["item-nav"]} ${styles["post"]}`}>
-            <NavItem link={"/post"} label={"게시물 작성"} icon={"post"} />
-          </li>
-          <li className={`${styles["item-nav"]} ${styles["profile"]}`}>
-            <NavItem
-              link={`/profile/${accountname}`}
-              label={"프로필"}
-              icon={"profile"}
-            />
-          </li>
-        </ul>
-      </curruntPageContext.Provider>
+      <ul className={styles["list-nav"]}>
+        <li className={`${styles["item-nav"]} ${styles["home"]}`}>
+          <NavItem link={"/"} label={"홈"} icon={"home"} />
+        </li>
+        <li className={`${styles["item-nav"]} ${styles["chat"]}`}>
+          <NavItem link={"/chat"} label={"채팅"} icon={"chat"} />
+        </li>
+        <li className={`${styles["item-nav"]} ${styles["post"]}`}>
+          <NavItem link={"/post"} label={"게시물 작성"} icon={"post"} />
+        </li>
+        <li className={`${styles["item-nav"]} ${styles["profile"]}`}>
+          <NavItem
+            link={`/profile/${accountname}`}
+            label={"프로필"}
+            icon={"profile"}
+          />
+        </li>
+      </ul>
     </nav>
   );
 }

--- a/src/contexts/curruntPageContext.jsx
+++ b/src/contexts/curruntPageContext.jsx
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+
+export const curruntPageContext = createContext({
+  location: "home",
+  setLocation: () => {}
+});

--- a/src/contexts/curruntPageContext.jsx
+++ b/src/contexts/curruntPageContext.jsx
@@ -1,6 +1,0 @@
-import { createContext } from "react";
-
-export const curruntPageContext = createContext({
-  location: "home",
-  setLocation: () => {}
-});


### PR DESCRIPTION
## 작업내용
#2 ContextAPI를 사용해 현재 탭에 하이라이트를 주려고 합니다.

하지만 하단바 중 프로필 탭만 하이라이트 되고 다른 컴포넌트들은 클릭해 위치가 이동되더라도 컬러가 바뀌지 않습니다.
![image](https://user-images.githubusercontent.com/102221305/180963848-f7c05057-9e33-4a4c-be1b-58b2bc18ae92.png)

## 중점적으로 봐주었으면 하는 부분
- 혹시 오류가 있어 보이는 부분이 있다면 알려주세요!
- 이걸 ContextAPI를 사용해서 처리하는 게 맞을까요...?
 - 차라리 `window.location.pathname`를 받아와서 path에 따라 변경되게 하거나
 - 페이지 컴포넌트에서 BottomNavigationBar컴포넌트에 props를 전달하는 편이 좋을까요?

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
