### PR TITLE
Design: 패딩 삭제 후의 패딩값 변경 및 이미지 비율 조절

### DIFF
--- a/src/components/atoms/ImageBox/imageBox.module.css
+++ b/src/components/atoms/ImageBox/imageBox.module.css
@@ -8,8 +8,8 @@
 }
 
 .image img {
-  max-height: 100%;
-  max-width: 100%;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
 }
 
@@ -27,11 +27,6 @@
 .square {
   width: 114px;
   height: 114px;
-}
-
-.square img {
-  height: 100%;
-  width: 100%;
 }
 
 /* 댓글에서 사용되는 프로필 이미지입니다. */
@@ -82,19 +77,9 @@
   max-width: 400px;
 }
 
-.rounded_square.medium_large img {
-  height: 100%;
-  width: 100%;
-}
-
 /* 상품 등록 페이지에서 사용될 이미지입니다. */
 .rounded_square.large {
   max-width: 320px;
   height: 204px;
   background-color: var(--whitegray-color);
-}
-
-.rounded_square img {
-  height: 100%;
-  width: 100%;
 }

--- a/src/components/organisms/FollowList/FollowList.jsx
+++ b/src/components/organisms/FollowList/FollowList.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import UserFollow from "../../modules/UserFollow/UserFollow";
 import styles from "./followList.module.css";
+import Logo from "../../../assets/icon-404-cat.png";
 
 function FollowList({ list }) {
   return list.length > 0 ? (
@@ -15,7 +16,7 @@ function FollowList({ list }) {
     </ul>
   ) : (
     <div className={styles["wrapper-message"]}>
-      <p className={`${styles["emoji"]}`}>😥</p>
+      <img src={Logo} />
       <p>아직 아무도 없어요.</p>
     </div>
   );

--- a/src/components/organisms/FollowList/followList.module.css
+++ b/src/components/organisms/FollowList/followList.module.css
@@ -1,6 +1,6 @@
 .list-follow {
   margin: 0 auto;
-  padding: 0 34px;
+  padding: 10px 34px;
 }
 
 .list-follow li {
@@ -8,13 +8,12 @@
 }
 
 .wrapper-message {
-  margin: 50px auto;
-  text-align: center;
+  margin-top: 25%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   font-size: 2rem;
+  gap: 10px;
   color: var(--middlegray-color);
-}
-
-.emoji {
-  margin: 20px auto;
-  font-size: 6rem;
 }

--- a/src/pages/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfileEditPage/ProfileEditPage.jsx
@@ -2,7 +2,6 @@ import React, { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import ProfileForm from "../../components/modules/ProfileForm/ProfileForm";
-import styles from "./profileEditPage.module.css";
 import { editProfile } from "./ProfileEditPageAPI";
 import { handleImageSize } from "../../common/ImageResize";
 import { uploadImage } from "../../common/ImageUpload";
@@ -53,7 +52,7 @@ function ProfileEditPage() {
   }
 
   return (
-    <section className={styles["wrapper-profile"]}>
+    <section className="wrapper-padding">
       <h1 className="a11y-hidden">프로필 수정 페이지</h1>
       <HeaderForm
         backButton={true}

--- a/src/pages/ProfileEditPage/profileEditPage.module.css
+++ b/src/pages/ProfileEditPage/profileEditPage.module.css
@@ -1,3 +1,0 @@
-.wrapper-profile > div {
-  padding: 0 34px;
-}

--- a/src/pages/SplashPage/splashPage.module.css
+++ b/src/pages/SplashPage/splashPage.module.css
@@ -5,7 +5,6 @@
 .wrapper-splash {
   box-sizing: border-box;
   height: 100vh;
-  margin: -48px auto -60px;
   padding: 82px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 작업내용
- wrapper-content 추가 후 #1, #13, #14 의 패딩을 재조절해 주었습니다.
#146, #148
- ImageBox 컴포넌트의 width, height 값을 모두 100%로 변경했습니다. 
#149
![image](https://user-images.githubusercontent.com/79434205/181256260-48f5341e-02b2-404f-a6c3-5f43fb81a6cd.png)

- #13 에서 팔로워/팔로잉이 없을 때 뜨는 창에서 이모지 대신 로고로 변경했습니다.
![image](https://user-images.githubusercontent.com/79434205/181253504-c941b084-fcf4-452a-a663-d1073ae951fc.png)

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 이미지 제대로 출력되는지 확인 부탁드립니다!
## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
