### PR TITLE
Feat: 게시물 및 댓글 신고 기능 추가 

### DIFF
--- a/src/components/modules/CommentForm/CommentForm.jsx
+++ b/src/components/modules/CommentForm/CommentForm.jsx
@@ -13,6 +13,7 @@ function CommentForm({
   createTime,
   text,
   handleDelete,
+  handleReport,
 }) {
   const navigate = useNavigate();
   const [onModal, setOnModal] = useState(false);
@@ -42,7 +43,7 @@ function CommentForm({
           buttons={
             myAccountname === accoutName
               ? [{ text: "삭제", onClick: () => handleDelete(id) }]
-              : [{ text: "신고" }]
+              : [{ text: "신고", onClick: () => handleReport(id) }]
           }
           name="댓글"
         />

--- a/src/components/modules/CommentForm/CommentForm.jsx
+++ b/src/components/modules/CommentForm/CommentForm.jsx
@@ -42,7 +42,7 @@ function CommentForm({
           buttons={
             myAccountname === accoutName
               ? [{ text: "삭제", onClick: () => handleDelete(id) }]
-              : [{ text: "신고 하기" }]
+              : [{ text: "신고" }]
           }
           name="댓글"
         />

--- a/src/components/modules/ModalRequestion/ModalRequestion.jsx
+++ b/src/components/modules/ModalRequestion/ModalRequestion.jsx
@@ -1,9 +1,19 @@
 import styles from "./modalRequestion.module.css";
 
 //로그아웃 또는 댓글, 게시글, 상품 삭제, 신고 재확인시 사용하는 모달
-function ModalRequestion({ onClose, requestData }) {
+function getModalText(requestData) {
   const name = requestData.name;
   const text = requestData.text;
+  if (text === "신고") {
+    return { modalText: "신고하시겠어요?", buttonText: "신고" };
+  } else if (name === "로그인") {
+    return { modalText: "로그아웃 하시겠어요?", buttonText: "로그아웃" };
+  } else {
+    return { modalText: `${name}을 삭제할까요?`, buttonText: "삭제" };
+  }
+}
+
+function ModalRequestion({ onClose, requestData }) {
   return (
     <div
       className={styles["wrapper-modal"]}
@@ -11,13 +21,7 @@ function ModalRequestion({ onClose, requestData }) {
         event.stopPropagation();
       }}
     >
-      <strong>
-        {text === "신고"
-          ? "신고하시겠습니까?"
-          : name === "로그인"
-          ? `로그아웃 하시겠어요?`
-          : `${name}을 삭제할까요?`}
-      </strong>
+      <strong>{getModalText(requestData).modalText}</strong>
       <button onClick={onClose}>취소</button>
       <button
         onClick={() => {
@@ -25,7 +29,7 @@ function ModalRequestion({ onClose, requestData }) {
           onClose();
         }}
       >
-        {text === "신고" ? "신고" : name === "로그인" ? "로그아웃" : "삭제"}
+        {getModalText(requestData).buttonText}
       </button>
     </div>
   );

--- a/src/components/modules/ModalRequestion/ModalRequestion.jsx
+++ b/src/components/modules/ModalRequestion/ModalRequestion.jsx
@@ -1,8 +1,9 @@
 import styles from "./modalRequestion.module.css";
 
-//로그아웃 또는 댓글, 게시글, 상품 삭제 재확인시 사용하는 모달
+//로그아웃 또는 댓글, 게시글, 상품 삭제, 신고 재확인시 사용하는 모달
 function ModalRequestion({ onClose, requestData }) {
   const name = requestData.name;
+  const text = requestData.text;
   return (
     <div
       className={styles["wrapper-modal"]}
@@ -11,7 +12,11 @@ function ModalRequestion({ onClose, requestData }) {
       }}
     >
       <strong>
-        {name === "로그인" ? `로그아웃 하시겠어요?` : `${name}을 삭제할까요?`}
+        {text === "신고"
+          ? "신고하시겠습니까?"
+          : name === "로그인"
+          ? `로그아웃 하시겠어요?`
+          : `${name}을 삭제할까요?`}
       </strong>
       <button onClick={onClose}>취소</button>
       <button
@@ -20,7 +25,7 @@ function ModalRequestion({ onClose, requestData }) {
           onClose();
         }}
       >
-        {name === "로그인" ? "로그아웃" : "삭제"}
+        {text === "신고" ? "신고" : name === "로그인" ? "로그아웃" : "삭제"}
       </button>
     </div>
   );

--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -8,7 +8,7 @@ import styles from "./postCard.module.css";
 import IconButton from "../../atoms/IconButton/IconButton";
 import Modal from "../../../components/organisms/Modal/Modal";
 import { Link } from "react-router-dom";
-import { deletePost } from "./PostCardAPI";
+import { deletePost, reportPost } from "./PostCardAPI";
 import { useNavigate } from "react-router-dom";
 
 function ImageListMaker({ image }) {
@@ -43,6 +43,9 @@ function PostCard({ post, setDeletePost }) {
   }
   function handlePostChange(postId) {
     navigate(`/post/edit/${postId}`);
+  }
+  async function handlePostReport(postId) {
+    await reportPost(postId);
   }
   return (
     <>
@@ -86,7 +89,7 @@ function PostCard({ post, setDeletePost }) {
                   { text: "삭제", onClick: () => handlePostDelete(post.id) },
                   { text: "수정", onClick: () => handlePostChange(post.id) },
                 ]
-              : [{ text: "신고" }]
+              : [{ text: "신고", onClick: () => handlePostReport(post.id) }]
           }
           name="게시글"
         />

--- a/src/components/modules/PostCard/PostCardAPI.js
+++ b/src/components/modules/PostCard/PostCardAPI.js
@@ -1,7 +1,7 @@
 import { BASE_URL } from "../../../common/BASE_URL";
 const TOKEN = window.localStorage.getItem("token");
 
-//게시물 삭제 함수
+//게시물 삭제
 async function deletePost(postId, setDeletePost) {
   try {
     await fetch(BASE_URL + `/post/${postId}`, {
@@ -17,4 +17,19 @@ async function deletePost(postId, setDeletePost) {
   setDeletePost && setDeletePost(postId);
 }
 
-export { deletePost };
+//게시물 신고
+async function reportPost(postId) {
+  try {
+    await fetch(BASE_URL + `/post/${postId}/report`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+
+export { deletePost, reportPost };

--- a/src/components/organisms/CommentList/CommentList.jsx
+++ b/src/components/organisms/CommentList/CommentList.jsx
@@ -20,7 +20,7 @@ function getTimeStamp(createdAt) {
   return `${Math.floor(elapsedYear)}년 전`;
 }
 
-function CommentList({ comments, handleDelete }) {
+function CommentList({ comments, handleDelete, handleReport }) {
   return (
     <ul className={styles["wrapper-comment"]}>
       {comments.map((item) => {
@@ -34,6 +34,7 @@ function CommentList({ comments, handleDelete }) {
               createTime={getTimeStamp(item.createdAt)}
               text={item.content}
               handleDelete={handleDelete}
+              handleReport={handleReport}
             />
           </li>
         );

--- a/src/components/organisms/Modal/Modal.jsx
+++ b/src/components/organisms/Modal/Modal.jsx
@@ -9,9 +9,9 @@ function Modal({ onClose, buttons, name }) {
   const [requestData, setRequestData] = useState();
   //버튼 클릭시 재확인 모달을 띄울지, 그냥 함수를 실행할지 판단
   function handleButtonClick(text, onClick) {
-    if (text === "삭제" || text === "로그아웃") {
+    if (text === "삭제" || text === "로그아웃" || text === "신고") {
       setRequestModal(!requestModal);
-      setRequestData({ name, onClick });
+      setRequestData({ name, onClick, text });
       return;
     }
     onClick();

--- a/src/pages/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage.jsx
@@ -5,6 +5,7 @@ import {
   getPostComment,
   uploadComment,
   deleteComment,
+  reportComment,
 } from "./PostPageAPI";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import PostCard from "../../components/modules/PostCard/PostCard";
@@ -37,6 +38,11 @@ function PostPage() {
     setChangeComments(commentId);
   }
 
+  //댓글 신고
+  async function handleReport(commentId) {
+    await reportComment(post.id, commentId);
+  }
+
   return (
     <section>
       <h1 className="a11y-hidden">게시글 상세 페이지</h1>
@@ -44,7 +50,11 @@ function PostPage() {
       <div className="wrapper-contents">
         {post && <PostCard post={post} />}
         {comments && (
-          <CommentList comments={comments} handleDelete={handleDelete} />
+          <CommentList
+            comments={comments}
+            handleDelete={handleDelete}
+            handleReport={handleReport}
+          />
         )}
         <MessageInput
           type="comment"

--- a/src/pages/PostPage/PostPageAPI.js
+++ b/src/pages/PostPage/PostPageAPI.js
@@ -68,4 +68,24 @@ async function deleteComment(postId, commentId) {
   }
 }
 
-export { getPostData, getPostComment, uploadComment, deleteComment };
+async function reportComment(postId, commentId) {
+  try {
+    await fetch(BASE_URL + `/post/${postId}/comments/${commentId}/report`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+
+export {
+  getPostData,
+  getPostComment,
+  uploadComment,
+  deleteComment,
+  reportComment,
+};


### PR DESCRIPTION
## 작업내용

- #153 
- 모달에서 신고하기 버튼 클릭시 재확인 버튼이 뜨도록 수정하였습니다. 
- 다른 사람의 게시글과 댓글에 신고하기 기능을 추가하였습니다. 
- 딱히 신고를 한다음에 UI에 변화는 없어서 api보내고 응답 받는것으로 잘 되는지 테스트를 해보았습니당!

### 게시글 신고하기 
![2022-07-27 22;46;10](https://user-images.githubusercontent.com/68495264/181263202-7eab5c90-d961-4f8d-87bf-abea491b1274.gif)

### 댓글 신고하기
![2022-07-27 22;46;47](https://user-images.githubusercontent.com/68495264/181263227-5e19f1ea-2ec8-4040-9b51-a5db7c42f54f.gif)


## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
