### PR TITLE
Fix: 화면이 좁아질 때 하단 탭 "게시글 추가"가 줄바꿈이 일어나는 현상 해결

### DIFF
--- a/src/components/atoms/NavItem/NavItem.jsx
+++ b/src/components/atoms/NavItem/NavItem.jsx
@@ -10,7 +10,7 @@ function NavItem({link, label, icon}) {
         to={link} 
         className={`${styles.link} ${styles[icon]} ${currunt ? styles.active : null}`}
       >
-        <span>{label}</span>
+        <span className={styles.label}>{label}</span>
       </Link>
   )
 }

--- a/src/components/atoms/NavItem/navItem.module.css
+++ b/src/components/atoms/NavItem/navItem.module.css
@@ -37,3 +37,16 @@
 .profile.active::before {
   background-image: url("../../../assets/icon-user-fill.svg");
 }
+
+@media screen and (max-width: 300px) {
+  .label {
+    overflow: hidden;
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    border: 0;
+    padding: 0;
+  }
+}

--- a/src/components/modules/BottomNavigateBar/bottomNavigateBar.module.css
+++ b/src/components/modules/BottomNavigateBar/bottomNavigateBar.module.css
@@ -9,15 +9,14 @@
 
 .list-nav {
   margin: 0 auto;
-  display: flex;
-  justify-content: space-around;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   max-width: 700px;
 }
 
 .item-nav {
-  flex-wrap: nowrap;
-  width: 84px;
-  padding: 12px 30px 6px;
+  margin: 0 auto;
+  padding: 12px 12px 6px;
   font-weight: 400;
   line-height: 14px;
   letter-spacing: 0em;


### PR DESCRIPTION
## 작업내용
#147 화면이 좁아질 경우 하단탭의 height가 높아져 페이지 하단 내용을 가리는 현상을 해결했습니다.

4개의 모든 아이콘이 같은 너비를 가지게 하려면 flex보다 grid가 적용이 쉬워 기존의 flex 레이아웃을 grid로 변경했습니다.

하지만 grid로 작업했을 때에도 너비가 계속 작아지면 글씨 영역이 깨질 수 밖에 없는데, 그럴 일은 잘 없겠지만 화면너비가 300px 이하일 때는 아이콘 이름이 사라지게 만들었습니다.
![하단바 조절](https://user-images.githubusercontent.com/102221305/181268848-36dc4fec-41e3-49a7-9c7f-a95416ff16ed.gif)

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
