### PR TITLE
Fix: 프로필 페이지의 게시글 앨범형으로 볼 때의 css 반응형으로 수정

### DIFF
--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -40,7 +40,7 @@ function ProfilePage() {
   useEffect(() => {
     getProducts(accountname, setProducts);
   }, [isDeleteProduct]);
-  
+
   useEffect(() => {
     getPosts(accountname, setPosts);
   }, [isDeletePost]);
@@ -54,7 +54,7 @@ function ProfilePage() {
           <UserProfile isMyProfile={isMyProfile} userProfile={profile} />
         )}
         {products && (
-           <ProductList
+          <ProductList
             isMyProfile={isMyProfile}
             products={products}
             setDeleteProduct={setDeleteProduct}
@@ -73,11 +73,14 @@ function ProfilePage() {
               </ol>
             ) : (
               <ol className={styles["list-image"]}>
-                {posts.map((post, index) => (
-                  <li key={index}>
-                    {post.image && <ImagePostCard post={post} />}
-                  </li>
-                ))}
+                {posts.map(
+                  (post, index) =>
+                    post.image && (
+                      <li key={index}>
+                        <ImagePostCard post={post} />
+                      </li>
+                    )
+                )}
               </ol>
             )}
           </section>

--- a/src/pages/ProfilePage/profilePage.module.css
+++ b/src/pages/ProfilePage/profilePage.module.css
@@ -1,7 +1,32 @@
 .list-image {
-  display: flex;
-  /* justify-content: center; */
-  flex-wrap: wrap;
+  margin: 0 auto;
+  display: grid;
+  justify-content: center;
+  grid-template-columns: repeat(6, 114px);
   gap: 8px;
   padding: 9px 16px;
+}
+
+@media screen and (max-width: 740px) {
+  .list-image {
+    grid-template-columns: repeat(5, 114px);
+  }
+}
+
+@media screen and (max-width: 620px) {
+  .list-image {
+    grid-template-columns: repeat(4, 114px);
+  }
+}
+
+@media screen and (max-width: 500px) {
+  .list-image {
+    grid-template-columns: repeat(3, 114px);
+  }
+}
+
+@media screen and (max-width: 380px) {
+  .list-image {
+    grid-template-columns: repeat(2, 114px);
+  }
 }


### PR DESCRIPTION
## 작업내용
- #11 의 게시글 목록에서 앨범형으로 볼 때의 css를 grid와 미디어 쿼리를 이용하여 수정했습니다.
#144 
![image](https://user-images.githubusercontent.com/79434205/181275236-bf32de4e-b536-49fe-9e40-a656b74d7691.png)
![image](https://user-images.githubusercontent.com/79434205/181275386-6d98c5a6-555c-46d3-b8c2-dab5f3639c2c.png)
![image](https://user-images.githubusercontent.com/79434205/181275049-7aa963ea-f23f-4c5b-afbf-9771782ac844.png)
![image](https://user-images.githubusercontent.com/79434205/181275535-8b51ef59-04bf-419b-a6db-3deebd5d907f.png)

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- image가 있는지 없는지를 li 안에 넣어 돌리고 있었습니다... 그래서 이미지가 없어도 li가 생기고 간격이 이상해졌었나 봐요...
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
