### PR TITLE
Fix: 로컬스토리지 대신 세션스토리지에 계정 정보 저장 및 프로필 사진 뜨도록 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Routes, Route } from "react-router-dom";
 import "./reset.css";
 import "./font.css";

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Routes, Route } from "react-router-dom";
 import "./reset.css";
 import "./font.css";
@@ -18,38 +18,55 @@ import PostPage from "./pages/PostPage/PostPage";
 import SearchPage from "./pages/SearchPage/SearchPage";
 import ChatListPage from "./pages/ChatListPage/ChatListPage";
 import PostEditPage from "./pages/PostEditPage/PostEditPage";
+import { LoginedUserContext } from "./contexts/LoginedUserContext";
 
 function App() {
+  const [user, setUser] = useState({});
+
+  useEffect(() => {
+    const loginedToken = window.sessionStorage.getItem("token");
+    const loginedAccountname = window.sessionStorage.getItem("accountname");
+    const loginedImage = window.sessionStorage.getItem("image");
+    const loginedData = {
+      token: loginedToken,
+      accountname: loginedAccountname,
+      image: loginedImage,
+    };
+    setUser(loginedData);
+  }, []);
+
   return (
-    <div className="max-width">
-      <h1 className="a11y-hidden">게임어스</h1>
-      <Routes>
-        <Route path="/" element={<SplashPage />} />
-        <Route path="/feed" element={<HomePage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
-        <Route path="/search" element={<SearchPage />} />
-        <Route path="/chat" element={<ChatListPage />} />
-        <Route path="/product" element={<AddProductPage />} />
-        <Route path="/profile/:accountname" element={<ProfilePage />} />
-        <Route
-          path="/profile/:accountname/follower"
-          element={<FollowerPage />}
-        />
-        <Route
-          path="/profile/:accountname/following"
-          element={<FollowingPage />}
-        />
-        <Route
-          path="/profile/:accountname/edit"
-          element={<ProfileEditPage />}
-        />
-        <Route path="/post" element={<UploadPage />} />
-        <Route path="/post/:postId" element={<PostPage />} />
-        <Route path="/post/edit/:postId" element={<PostEditPage />} />
-        <Route path="/*" element={<ErrorPage />} />
-      </Routes>
-    </div>
+    <LoginedUserContext.Provider value={{ user, setUser }}>
+      <div className="max-width">
+        <h1 className="a11y-hidden">게임어스</h1>
+        <Routes>
+          <Route path="/" element={<SplashPage />} />
+          <Route path="/feed" element={<HomePage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/search" element={<SearchPage />} />
+          <Route path="/chat" element={<ChatListPage />} />
+          <Route path="/product" element={<AddProductPage />} />
+          <Route path="/profile/:accountname" element={<ProfilePage />} />
+          <Route
+            path="/profile/:accountname/follower"
+            element={<FollowerPage />}
+          />
+          <Route
+            path="/profile/:accountname/following"
+            element={<FollowingPage />}
+          />
+          <Route
+            path="/profile/:accountname/edit"
+            element={<ProfileEditPage />}
+          />
+          <Route path="/post" element={<UploadPage />} />
+          <Route path="/post/:postId" element={<PostPage />} />
+          <Route path="/post/edit/:postId" element={<PostEditPage />} />
+          <Route path="/*" element={<ErrorPage />} />
+        </Routes>
+      </div>
+    </LoginedUserContext.Provider>
   );
 }
 

--- a/src/common/ImageUpload.js
+++ b/src/common/ImageUpload.js
@@ -1,4 +1,4 @@
-import { BASE_URL } from "./BASE_URL.jsx";
+import { BASE_URL } from "./BASE_URL";
 
 //이미지 업로드 - 한 개, 여러개
 async function uploadImage(files) {

--- a/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
+++ b/src/components/modules/BottomNavigateBar/BottomNavigateBar.jsx
@@ -2,7 +2,7 @@ import NavItem from "../../atoms/NavItem/NavItem";
 import styles from "./bottomNavigateBar.module.css";
 
 function BottomNavigateBar() {
-  const accountname = localStorage.getItem("accountname");
+  const accountname = window.sessionStorage.getItem("accountname");
 
   return (
     <nav className={styles["nav"]}>

--- a/src/components/modules/HeaderForm/HeaderForm.jsx
+++ b/src/components/modules/HeaderForm/HeaderForm.jsx
@@ -23,8 +23,7 @@ function HeaderForm({
   const [onModal, setOnModal] = useState(false);
   //로그아웃 함수
   function handleLogout() {
-    window.localStorage.removeItem("accountname");
-    window.localStorage.removeItem("token");
+    window.sessionStorage.clear();
     navigate("/");
   }
   return (

--- a/src/components/modules/LoginForm/LoginForm.jsx
+++ b/src/components/modules/LoginForm/LoginForm.jsx
@@ -87,14 +87,14 @@ function LoginForm({
           password: "이메일 또는 비밀번호가 일치하지 않습니다.",
         });
       } else {
-        // 로컬 스토리지에 accountname 저장
-        window.localStorage.setItem("accountname", result.user.accountname);
-        // 로컬 스토리지에 토큰 저장
-        window.localStorage.setItem("token", result.user.token);
+        // 토큰 검증 과정 필요
+
+        // 검증이 끝나면 세션 스토리지에 토큰, 계정 ID, 이미지 저장
+        window.sessionStorage.setItem("token", result.user.token);
+        window.sessionStorage.setItem("accountname", result.user.accountname);
+        window.sessionStorage.setItem("image", result.user.image);
         navigate("/feed");
       }
-      // if (!error.email && !error.password) {
-      // }
     }
   }
 

--- a/src/components/modules/LoginForm/LoginForm.jsx
+++ b/src/components/modules/LoginForm/LoginForm.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import InputBox from "../../atoms/InputBox/InputBox";
 import Button from "../../atoms/Button/Button";
 import styles from "./loginForm.module.css";
 import { BASE_URL } from "../../../common/BASE_URL";
 import { postLogin } from "../../../pages/LoginPage/LoginPageAPI";
+import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 
 function LoginForm({
   label,
@@ -24,6 +25,8 @@ function LoginForm({
   const emailRegExp = /^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/i;
 
   const navigate = useNavigate();
+
+  const { setUser } = useContext(LoginedUserContext);
 
   // email과 password 내용이 바뀌면 에러가 표시되지 않도록 비웁니다.
   useEffect(() => {
@@ -93,6 +96,12 @@ function LoginForm({
         window.sessionStorage.setItem("token", result.user.token);
         window.sessionStorage.setItem("accountname", result.user.accountname);
         window.sessionStorage.setItem("image", result.user.image);
+        const loginedData = {
+          token: window.sessionStorage.getItem("token"),
+          accountname: window.sessionStorage.getItem("accountname"),
+          image: window.sessionStorage.getItem("image"),
+        };
+        setUser(loginedData);
         navigate("/feed");
       }
     }

--- a/src/components/modules/UploadText/UploadText.jsx
+++ b/src/components/modules/UploadText/UploadText.jsx
@@ -3,9 +3,16 @@ import TextArea from "../../atoms/TextArea/TextArea";
 import styles from "./uploadText.module.css";
 
 function UploadText({ handleText, text }) {
+  const myImage = window.sessionStorage.getItem("image");
+
   return (
     <div className={styles["wrapper-post"]}>
-      <ImageBox src="" type="circle" size="medium_small" alt="프로필 이미지" />
+      <ImageBox
+        src={myImage}
+        type="circle"
+        size="medium_small"
+        alt="프로필 이미지"
+      />
       <TextArea label="게시글 입력" handleText={handleText} text={text} />
     </div>
   );

--- a/src/components/modules/UploadText/UploadText.jsx
+++ b/src/components/modules/UploadText/UploadText.jsx
@@ -1,14 +1,16 @@
+import { useContext } from "react";
+import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 import ImageBox from "../../atoms/ImageBox/ImageBox";
 import TextArea from "../../atoms/TextArea/TextArea";
 import styles from "./uploadText.module.css";
 
 function UploadText({ handleText, text }) {
-  const myImage = window.sessionStorage.getItem("image");
+  const { user } = useContext(LoginedUserContext);
 
   return (
     <div className={styles["wrapper-post"]}>
       <ImageBox
-        src={myImage}
+        src={user.image}
         type="circle"
         size="medium_small"
         alt="프로필 이미지"

--- a/src/contexts/LoginedUserContext.jsx
+++ b/src/contexts/LoginedUserContext.jsx
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+export const LoginedUserContext = createContext({
+  token: null,
+  accountname: null,
+  image: null,
+});

--- a/src/pages/AddProductPage/AddProductPage.jsx
+++ b/src/pages/AddProductPage/AddProductPage.jsx
@@ -14,7 +14,7 @@ function AddProductPage() {
   const [link, setLink] = useState("");
   const [nameError, setNameError] = useState(false);
   const [priceError, setPriceError] = useState(false);
-  const myAccountname = window.localStorage.getItem("accountname");
+  const myAccountname = window.sessionStorage.getItem("accountname");
   //이미지 프리뷰
   async function saveImage(event) {
     const file = event.target.files[0];

--- a/src/pages/AddProductPage/AddProductPage.jsx
+++ b/src/pages/AddProductPage/AddProductPage.jsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { handleImageSize } from "../../common/ImageResize";
 import { uploadImage } from "../../common/ImageUpload";
 import { postProduct } from "./AddProductPageAPI";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import AddProduct from "../../components/organisms/AddProduct/AddProduct";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function AddProductPage() {
   const navigate = useNavigate();
@@ -14,7 +15,9 @@ function AddProductPage() {
   const [link, setLink] = useState("");
   const [nameError, setNameError] = useState(false);
   const [priceError, setPriceError] = useState(false);
-  const myAccountname = window.sessionStorage.getItem("accountname");
+
+  const { user } = useContext(LoginedUserContext);
+
   //이미지 프리뷰
   async function saveImage(event) {
     const file = event.target.files[0];
@@ -57,9 +60,9 @@ function AddProductPage() {
   async function handleSubmit() {
     const compressedFile = await handleImageSize(image.data);
     const fileUrl = await uploadImage(compressedFile);
-    await postProduct(name, price, link, fileUrl);
+    await postProduct(user.token, name, price, link, fileUrl);
     URL.revokeObjectURL(image.src);
-    navigate(`/profile/${myAccountname}`);
+    navigate(`/profile/${user.accountname}`);
   }
 
   return (

--- a/src/pages/AddProductPage/AddProductPageAPI.js
+++ b/src/pages/AddProductPage/AddProductPageAPI.js
@@ -1,6 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.localStorage.getItem("token");
+const TOKEN = window.sessionStorage.getItem("token");
 
 async function postProduct(name, price, link, fileUrl) {
   const data = {

--- a/src/pages/AddProductPage/AddProductPageAPI.js
+++ b/src/pages/AddProductPage/AddProductPageAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function postProduct(name, price, link, fileUrl) {
+async function postProduct(TOKEN, name, price, link, fileUrl) {
   const data = {
     product: {
       itemName: name,

--- a/src/pages/FollowerPage/FollowerPage.jsx
+++ b/src/pages/FollowerPage/FollowerPage.jsx
@@ -5,14 +5,17 @@ import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../../components/organisms/FollowList/FollowList";
 import { getFollowers } from "./FollowerPageAPI";
+import { useContext } from "react";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function FollowerPage() {
   // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.
   let { accountname } = useParams();
   const [followers, setFollowers] = useState(null);
+  const { user } = useContext(LoginedUserContext);
 
   useEffect(() => {
-    getFollowers(accountname, setFollowers);
+    getFollowers(user.token, accountname, setFollowers);
   }, [accountname]);
 
   return (

--- a/src/pages/FollowerPage/FollowerPageAPI.js
+++ b/src/pages/FollowerPage/FollowerPageAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function getFollowers(accountname, setFollowers) {
+async function getFollowers(TOKEN, accountname, setFollowers) {
   try {
     const data = await fetch(
       BASE_URL + `/profile/${accountname}/follower?limit=Infinity`,

--- a/src/pages/FollowerPage/FollowerPageAPI.js
+++ b/src/pages/FollowerPage/FollowerPageAPI.js
@@ -1,7 +1,8 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
+const TOKEN = window.sessionStorage.getItem("token");
+
 async function getFollowers(accountname, setFollowers) {
-  const TOKEN = window.localStorage.getItem("token");
   try {
     const data = await fetch(
       BASE_URL + `/profile/${accountname}/follower?limit=Infinity`,

--- a/src/pages/FollowingPage/FollowingPage.jsx
+++ b/src/pages/FollowingPage/FollowingPage.jsx
@@ -1,18 +1,20 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../../components/organisms/FollowList/FollowList";
 import { getFollowings } from "./FollowingPageAPI";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function FollowingPage() {
   // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.
   let { accountname } = useParams();
   const [followings, setFollowings] = useState(null);
+  const { user } = useContext(LoginedUserContext);
 
   useEffect(() => {
-    getFollowings(accountname, setFollowings);
+    getFollowings(user.token, accountname, setFollowings);
   }, [accountname]);
 
   return (

--- a/src/pages/FollowingPage/FollowingPageAPI.js
+++ b/src/pages/FollowingPage/FollowingPageAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function getFollowings(accountname, setFollowings) {
+async function getFollowings(TOKEN, accountname, setFollowings) {
   try {
     const data = await fetch(
       BASE_URL + `/profile/${accountname}/following?limit=Infinity`,

--- a/src/pages/FollowingPage/FollowingPageAPI.js
+++ b/src/pages/FollowingPage/FollowingPageAPI.js
@@ -1,7 +1,8 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
+const TOKEN = window.sessionStorage.getItem("token");
+
 async function getFollowings(accountname, setFollowings) {
-  const TOKEN = window.localStorage.getItem("token");
   try {
     const data = await fetch(
       BASE_URL + `/profile/${accountname}/following?limit=Infinity`,

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -16,7 +16,7 @@ function HomePage() {
   // const skip_amount = 5;
 
   const REQ_PATH = `/post/feed/?limit=${post_limit}&skip=${post_skip}`;
-  const TOKEN = window.localStorage.getItem("token");
+  const TOKEN = window.sessionStorage.getItem("token");
 
   // 팔로우하는 유저의 게시글 목록을 posts state에 받아옵니다.
   useLayoutEffect(() => {
@@ -53,27 +53,27 @@ function HomePage() {
       <HeaderForm title={"홈 피드"} searchButton={true} titleSize={"large"} />
       <div className="wrapper-contents">
         {posts &&
-        (posts.length === 0 ? (
-          <div className={styles["container-search_notice"]}>
-            <img src={catImageURL} />
-            <p className={styles["text"]}>유저를 검색해 팔로우 해보세요!</p>
-            <Button
-              href={"/search"}
-              size="medium"
-              label={"검색하기"}
-              active={true}
-              primary={true}
-            />
-          </div>
-        ) : (
-          <ul>
-            {posts.map((post, index) => (
-              <li key={index}>
-                <PostCard post={post} />
-              </li>
-            ))}
-          </ul>
-        ))}
+          (posts.length === 0 ? (
+            <div className={styles["container-search_notice"]}>
+              <img src={catImageURL} />
+              <p className={styles["text"]}>유저를 검색해 팔로우 해보세요!</p>
+              <Button
+                href={"/search"}
+                size="medium"
+                label={"검색하기"}
+                active={true}
+                primary={true}
+              />
+            </div>
+          ) : (
+            <ul>
+              {posts.map((post, index) => (
+                <li key={index}>
+                  <PostCard post={post} />
+                </li>
+              ))}
+            </ul>
+          ))}
       </div>
       <BottomNavigateBar />
     </section>

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -6,6 +6,8 @@ import catImageURL from "../../assets/icon-404-cat.png";
 import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 import styles from "./homePage.module.css";
 import { BASE_URL } from "../../common/BASE_URL";
+import { useContext } from "react";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function HomePage() {
   const [posts, setPosts] = useState(null);
@@ -16,7 +18,8 @@ function HomePage() {
   // const skip_amount = 5;
 
   const REQ_PATH = `/post/feed/?limit=${post_limit}&skip=${post_skip}`;
-  const TOKEN = window.sessionStorage.getItem("token");
+
+  const { user } = useContext(LoginedUserContext);
 
   // 팔로우하는 유저의 게시글 목록을 posts state에 받아옵니다.
   useLayoutEffect(() => {
@@ -25,7 +28,7 @@ function HomePage() {
         const response = await fetch(BASE_URL + REQ_PATH, {
           method: "GET",
           headers: {
-            Authorization: `Bearer ${TOKEN}`,
+            Authorization: `Bearer ${user.token}`,
             "Content-type": "application/json",
           },
         });

--- a/src/pages/PostEditPage/PostEditPage.jsx
+++ b/src/pages/PostEditPage/PostEditPage.jsx
@@ -1,20 +1,22 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { handleImageSize } from "../../common/ImageResize";
 import { uploadImage } from "../../common/ImageUpload";
 import { getPostData, editPostData } from "./PostEditPageAPI";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import UploadForm from "../../components/organisms/UploadForm/UploadForm";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function UploadPage() {
   let { postId } = useParams();
   const navigate = useNavigate();
   const [text, setText] = useState("");
   const [images, setImages] = useState([]);
-  const myAccountname = window.sessionStorage.getItem("accountname");
+
+  const { user } = useContext(LoginedUserContext);
 
   useEffect(() => {
-    getPostData(postId, setText, setImages);
+    getPostData(user.token, postId, setText, setImages);
   }, [postId]);
 
   //이미지 업로드
@@ -34,8 +36,8 @@ function UploadPage() {
   //업로드 버튼
   async function handleUploadButton() {
     const imageNames = await handleuploadImages(images);
-    await editPostData(postId, imageNames, text);
-    navigate(`/profile/${myAccountname}`);
+    await editPostData(user.token, postId, imageNames, text);
+    navigate(`/profile/${user.accountname}`);
   }
 
   return (

--- a/src/pages/PostEditPage/PostEditPage.jsx
+++ b/src/pages/PostEditPage/PostEditPage.jsx
@@ -11,7 +11,7 @@ function UploadPage() {
   const navigate = useNavigate();
   const [text, setText] = useState("");
   const [images, setImages] = useState([]);
-  const myAccountname = window.localStorage.getItem("accountname");
+  const myAccountname = window.sessionStorage.getItem("accountname");
 
   useEffect(() => {
     getPostData(postId, setText, setImages);
@@ -47,7 +47,7 @@ function UploadPage() {
         onClick={handleUploadButton}
         active={text && true}
       />
-      <div className="wrapper-contents">  
+      <div className="wrapper-contents">
         <UploadForm
           images={images}
           setText={setText}

--- a/src/pages/PostEditPage/PostEditPageAPI.js
+++ b/src/pages/PostEditPage/PostEditPageAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function getPostData(postId, setText, setImages) {
+async function getPostData(TOKEN, postId, setText, setImages) {
   try {
     const response = await fetch(BASE_URL + `/post/${postId}`, {
       method: "GET",
@@ -29,7 +27,7 @@ async function getPostData(postId, setText, setImages) {
   }
 }
 
-async function editPostData(postId, imageNames, text) {
+async function editPostData(TOKEN, postId, imageNames, text) {
   const imageData = imageNames ? imageNames : "";
   const data = {
     post: {

--- a/src/pages/PostEditPage/PostEditPageAPI.js
+++ b/src/pages/PostEditPage/PostEditPageAPI.js
@@ -1,5 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
-const TOKEN = window.localStorage.getItem("token");
+
+const TOKEN = window.sessionStorage.getItem("token");
 
 async function getPostData(postId, setText, setImages) {
   try {

--- a/src/pages/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage.jsx
@@ -18,7 +18,7 @@ function PostPage() {
   const [post, setPost] = useState();
   const [comments, setComments] = useState([]);
   const [changeComments, setChangeComments] = useState(false);
- 
+
   const { user } = useContext(LoginedUserContext);
 
   useEffect(() => {

--- a/src/pages/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage.jsx
@@ -17,6 +17,7 @@ function PostPage() {
   const [post, setPost] = useState();
   const [comments, setComments] = useState([]);
   const [changeComments, setChangeComments] = useState(false);
+  const myImage = window.sessionStorage.getItem("image");
 
   useEffect(() => {
     getPostComment(postId, setComments);
@@ -48,7 +49,7 @@ function PostPage() {
         )}
         <MessageInput
           type="comment"
-          src=""
+          src={myImage}
           title="댓글"
           placeholder="댓글 입력하기..."
           buttonText="게시"

--- a/src/pages/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage.jsx
@@ -43,7 +43,7 @@ function PostPage() {
 
   //댓글 신고
   async function handleReport(commentId) {
-    await reportComment(post.id, commentId);
+    await reportComment(user.token, post.id, commentId);
   }
 
   return (

--- a/src/pages/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useContext } from "react";
 import { useParams } from "react-router-dom";
 import {
   getPostData,
@@ -10,6 +10,7 @@ import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import PostCard from "../../components/modules/PostCard/PostCard";
 import CommentList from "../../components/organisms/CommentList/CommentList";
 import MessageInput from "../../components/modules/MessageInput/MessageInput";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function PostPage() {
   let { postId } = useParams();
@@ -17,24 +18,25 @@ function PostPage() {
   const [post, setPost] = useState();
   const [comments, setComments] = useState([]);
   const [changeComments, setChangeComments] = useState(false);
-  const myImage = window.sessionStorage.getItem("image");
+ 
+  const { user } = useContext(LoginedUserContext);
 
   useEffect(() => {
-    getPostComment(postId, setComments);
-    getPostData(postId, setPost);
+    getPostComment(user.token, postId, setComments);
+    getPostData(user.token, postId, setPost);
   }, [postId, changeComments]);
 
   //댓글 입력 및 추가
   async function handleTextInput() {
     const inputText = inputRef.current.value;
     inputRef.current.value = "";
-    await uploadComment(postId, inputText);
+    await uploadComment(user.token, postId, inputText);
     setChangeComments(inputText);
   }
 
   //댓글 삭제
   async function handleDelete(commentId) {
-    await deleteComment(postId, commentId);
+    await deleteComment(user.token, postId, commentId);
     setChangeComments(commentId);
   }
 
@@ -49,7 +51,7 @@ function PostPage() {
         )}
         <MessageInput
           type="comment"
-          src={myImage}
+          src={user.image}
           title="댓글"
           placeholder="댓글 입력하기..."
           buttonText="게시"

--- a/src/pages/PostPage/PostPageAPI.js
+++ b/src/pages/PostPage/PostPageAPI.js
@@ -66,7 +66,7 @@ async function deleteComment(TOKEN, postId, commentId) {
   }
 }
 
-async function reportComment(postId, commentId) {
+async function reportComment(TOKEN, postId, commentId) {
   try {
     await fetch(BASE_URL + `/post/${postId}/comments/${commentId}/report`, {
       method: "POST",

--- a/src/pages/PostPage/PostPageAPI.js
+++ b/src/pages/PostPage/PostPageAPI.js
@@ -1,6 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.localStorage.getItem("token");
+const TOKEN = window.sessionStorage.getItem("token");
 
 async function getPostData(postId, setPost) {
   try {

--- a/src/pages/PostPage/PostPageAPI.js
+++ b/src/pages/PostPage/PostPageAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function getPostData(postId, setPost) {
+async function getPostData(TOKEN, postId, setPost) {
   try {
     const response = await fetch(BASE_URL + `/post/${postId}`, {
       method: "GET",
@@ -18,7 +16,7 @@ async function getPostData(postId, setPost) {
   }
 }
 
-async function getPostComment(postId, setComments) {
+async function getPostComment(TOKEN, postId, setComments) {
   try {
     const response = await fetch(BASE_URL + `/post/${postId}/comments`, {
       method: "GET",
@@ -34,7 +32,7 @@ async function getPostComment(postId, setComments) {
   }
 }
 
-async function uploadComment(postId, text) {
+async function uploadComment(TOKEN, postId, text) {
   const commentData = {
     comment: {
       content: text,
@@ -54,7 +52,7 @@ async function uploadComment(postId, text) {
   }
 }
 
-async function deleteComment(postId, commentId) {
+async function deleteComment(TOKEN, postId, commentId) {
   try {
     await fetch(BASE_URL + `/post/${postId}/comments/${commentId}`, {
       method: "DELETE",

--- a/src/pages/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfileEditPage/ProfileEditPage.jsx
@@ -52,7 +52,7 @@ function ProfileEditPage() {
   }
 
   return (
-    <section className={styles["wrapper-profile"]}>
+    <section className="wrapper-padding">
       <h2 className="a11y-hidden">프로필 수정 페이지</h2>
       <HeaderForm
         backButton={true}

--- a/src/pages/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfileEditPage/ProfileEditPage.jsx
@@ -1,10 +1,11 @@
-import React, { useRef, useState } from "react";
+import React, { useContext, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import ProfileForm from "../../components/modules/ProfileForm/ProfileForm";
 import { editProfile } from "./ProfileEditPageAPI";
 import { handleImageSize } from "../../common/ImageResize";
 import { uploadImage } from "../../common/ImageUpload";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function ProfileEditPage() {
   const [value, setValue] = useState({
@@ -26,6 +27,7 @@ function ProfileEditPage() {
   const usernameInput = useRef();
   const accountnameInput = useRef();
 
+  const { user } = useContext(LoginedUserContext);
   const navigate = useNavigate();
 
   async function handleEdit() {
@@ -46,7 +48,7 @@ function ProfileEditPage() {
       }
 
       const reqData = { user: { ...data } };
-      await editProfile(reqData);
+      await editProfile(user.token, reqData);
       navigate(`/profile/${value.accountname}`);
     }
   }

--- a/src/pages/ProfileEditPage/ProfileEditPageAPI.js
+++ b/src/pages/ProfileEditPage/ProfileEditPageAPI.js
@@ -1,7 +1,8 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
+const TOKEN = window.sessionStorage.getItem("token");
+
 async function editProfile(reqData) {
-  const TOKEN = window.localStorage.getItem("token");
   try {
     const data = await fetch(BASE_URL + "/user", {
       method: "PUT",

--- a/src/pages/ProfileEditPage/ProfileEditPageAPI.js
+++ b/src/pages/ProfileEditPage/ProfileEditPageAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function editProfile(reqData) {
+async function editProfile(TOKEN, reqData) {
   try {
     const data = await fetch(BASE_URL + "/user", {
       method: "PUT",

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -10,6 +10,8 @@ import ImagePostCard from "../../components/modules/ImagePostCard/ImagePostCard"
 import styles from "./profilePage.module.css";
 import { getProfile, getProducts, getPosts } from "./ProfilePageAPI";
 import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
+import { useContext } from "react";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function ProfilePage() {
   // useParams()를 사용하여 url에 있는 파라미터(accountname)를 받아옵니다.
@@ -23,26 +25,26 @@ function ProfilePage() {
   const [isDeletePost, setDeletePost] = useState("");
   const [isDeleteProduct, setDeleteProduct] = useState("");
 
-  const myAccountname = window.sessionStorage.getItem("accountname");
+  const { user } = useContext(LoginedUserContext);
 
   useEffect(() => {
     // 사용자의 프로필 정보를 받아오는 함수입니다.
-    if (myAccountname === accountname) {
+    if (user.accountname === accountname) {
       setIsMyProfile(true);
     } else {
       setIsMyProfile(false);
     }
-    getProfile(accountname, setProfile);
-    getProducts(accountname, setProducts);
-    getPosts(accountname, setPosts);
-  }, [accountname, myAccountname]);
+    getProfile(user.token, accountname, setProfile);
+    getProducts(user.token, accountname, setProducts);
+    getPosts(user.token, accountname, setPosts);
+  }, [accountname, user]);
 
   useEffect(() => {
-    getProducts(accountname, setProducts);
+    getProducts(user.token, accountname, setProducts);
   }, [isDeleteProduct]);
 
   useEffect(() => {
-    getPosts(accountname, setPosts);
+    getPosts(user.token, accountname, setPosts);
   }, [isDeletePost]);
 
   return (

--- a/src/pages/ProfilePage/ProfilePageAPI.js
+++ b/src/pages/ProfilePage/ProfilePageAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function getProfile(accountname, setProfile) {
+async function getProfile(TOKEN, accountname, setProfile) {
   try {
     const data = await fetch(BASE_URL + `/profile/${accountname}`, {
       method: "GET",
@@ -19,7 +17,7 @@ async function getProfile(accountname, setProfile) {
 }
 
 // 사용자의 상품 리스트를 받아오는 함수입니다.
-async function getProducts(accountname, setProducts) {
+async function getProducts(TOKEN, accountname, setProducts) {
   try {
     const data = await fetch(BASE_URL + `/product/${accountname}`, {
       method: "GET",
@@ -35,7 +33,7 @@ async function getProducts(accountname, setProducts) {
   }
 }
 
-async function getPosts(accountname, setPosts) {
+async function getPosts(TOKEN, accountname, setPosts) {
   try {
     const data = await fetch(BASE_URL + `/post/${accountname}/userpost`, {
       method: "GET",

--- a/src/pages/ProfilePage/ProfilePageAPI.js
+++ b/src/pages/ProfilePage/ProfilePageAPI.js
@@ -1,6 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.localStorage.getItem("token");
+const TOKEN = window.sessionStorage.getItem("token");
 
 async function getProfile(accountname, setProfile) {
   try {

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -41,7 +41,7 @@ function SearchPage() {
               </div>
             </Link>
           </li>
-        </ul>        
+        </ul>
       </div>
       <BottomNavigateBar />
     </section>

--- a/src/pages/SplashPage/SplashPage.jsx
+++ b/src/pages/SplashPage/SplashPage.jsx
@@ -3,20 +3,31 @@ import { useEffect, useState } from "react";
 import Logo from "../../assets/logo-main.svg";
 import styles from "./splashPage.module.css";
 import { useNavigate } from "react-router-dom";
+import { useContext } from "react";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function SplashPage() {
   const [visible, setVisible] = useState(false);
   const navigate = useNavigate();
-  const TOKEN = window.localStorage.getItem("token");
+  const { user, setUser } = useContext(LoginedUserContext);
 
   function handleNavigate() {
-    if (!TOKEN) {
+    if (!user.token) {
       navigate("/login");
     } else {
       navigate("/feed");
     }
   }
   useEffect(() => {
+    const loginedToken = window.sessionStorage.getItem("token");
+    const loginedAccountname = window.sessionStorage.getItem("accountname");
+    const loginedImage = window.sessionStorage.getItem("image");
+    const loginedData = {
+      token: loginedToken,
+      accountname: loginedAccountname,
+      image: loginedImage,
+    };
+    setUser(loginedData);
     setVisible(true);
   }, []);
   return (

--- a/src/pages/UploadPage/UploadAPI.js
+++ b/src/pages/UploadPage/UploadAPI.js
@@ -1,8 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.sessionStorage.getItem("token");
-
-async function uploadData(imageNames, text) {
+async function uploadData(TOKEN, imageNames, text) {
   const imageData = imageNames ? imageNames : "";
   const data = {
     post: {

--- a/src/pages/UploadPage/UploadAPI.js
+++ b/src/pages/UploadPage/UploadAPI.js
@@ -1,6 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-const TOKEN = window.localStorage.getItem("token");
+const TOKEN = window.sessionStorage.getItem("token");
 
 async function uploadData(imageNames, text) {
   const imageData = imageNames ? imageNames : "";

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -1,16 +1,17 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { handleImageSize } from "../../common/ImageResize";
 import { uploadImage } from "../../common/ImageUpload";
 import { uploadData } from "./UploadAPI";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import UploadForm from "../../components/organisms/UploadForm/UploadForm";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function UploadPage() {
   const navigate = useNavigate();
   const [text, setText] = useState("");
   const [images, setImages] = useState([]);
-  const myAccountname = window.sessionStorage.getItem("accountname");
+  const { user } = useContext(LoginedUserContext);
 
   //이미지 업로드
   async function handleuploadImages(images) {
@@ -24,10 +25,10 @@ function UploadPage() {
   //업로드 버튼
   async function handleUploadButton() {
     const imageNames = await handleuploadImages(images);
-    await uploadData(imageNames, text);
+    await uploadData(user.token, imageNames, text);
     //메모리 누수 방지
     images.forEach((file) => URL.revokeObjectURL(file.src));
-    navigate(`/profile/${myAccountname}`);
+    navigate(`/profile/${user.accountname}`);
   }
 
   return (

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -10,7 +10,7 @@ function UploadPage() {
   const navigate = useNavigate();
   const [text, setText] = useState("");
   const [images, setImages] = useState([]);
-  const myAccountname = window.localStorage.getItem("accountname");
+  const myAccountname = window.sessionStorage.getItem("accountname");
 
   //이미지 업로드
   async function handleuploadImages(images) {


### PR DESCRIPTION
## 작업내용
- 로컬스토리지에 저장했던 토큰 등을 세션스토리지에 저장하게 수정하였습니다.
- 세션스토리지에 저장한 프로필 이미지를 필요한 곳에 적용하였습니다.
![image](https://user-images.githubusercontent.com/79434205/181299749-95221462-6444-4c72-8c35-c1629530bb93.png)
![image](https://user-images.githubusercontent.com/79434205/181300143-9cc35ac1-992d-4ec7-bb46-b51ab80dde7b.png)
**- (추가!) 세션 스토리지의 정보를 매번 불러오는 것이 아니라 useContext를 이용하여 관리하게 수정했습니다.**
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 토큰이 없을 때: 로그인할 때 세션 스토리지에 정보를 저장하고, 동시에 세션 스토리지에서 정보를 받아와서 context에 세팅합니다. (로그인하면 바로 피드 페이지로 이동하기 때문에)
- 토큰이 있을 때: 스플래시와 App.jsx에서 세션 스토리지에서 정보를 받아와서 context에 세팅합니다.
App.jsx에서 하고는 있지만, 스플래시가 초기 화면이라 안전장치로 스플래시도 해줬는데 스플래시에서 빼도 정상작동하는 걸 확인하면 스플래시는 뺄게요! 
- 로그아웃하면 세션 스토리지를 초기화합니다.
- 그 외의 페이지에선 context에서 토큰, 계정 ID, 프로필 이미지를 받아와서 사용합니다.
매번 세션 스토리지에 접근하는 것보다 낫지 않을까 해서 한 건데 성능 향상에 효과가 있을지는 모르겠습니다 😅 
- @boram2445 님께서 말씀해 주셨던 로그아웃하고 나서 다시 로그인해서 댓글쓸때 이전 계정으로 쓰이는 문제는 저는 해결된 거 같은데 테스트 부탁드립니다!
## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
