### PR TITLE
Fix: 프로필 수정 후에도 기존 accountname과 비교하고 있던 오류 수정

### DIFF
--- a/src/pages/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfileEditPage/ProfileEditPage.jsx
@@ -27,7 +27,7 @@ function ProfileEditPage() {
   const usernameInput = useRef();
   const accountnameInput = useRef();
 
-  const { user } = useContext(LoginedUserContext);
+  const { user, setUser } = useContext(LoginedUserContext);
   const navigate = useNavigate();
 
   async function handleEdit() {
@@ -48,7 +48,10 @@ function ProfileEditPage() {
       }
 
       const reqData = { user: { ...data } };
-      await editProfile(user.token, reqData);
+      const newAccountname = await editProfile(user.token, reqData);
+      window.sessionStorage.setItem("accountname", newAccountname);
+      const updatedUser = { ...user, accountname: newAccountname };
+      setUser(updatedUser);
       navigate(`/profile/${value.accountname}`);
     }
   }

--- a/src/pages/ProfileEditPage/ProfileEditPageAPI.js
+++ b/src/pages/ProfileEditPage/ProfileEditPageAPI.js
@@ -11,7 +11,7 @@ async function editProfile(TOKEN, reqData) {
       body: JSON.stringify(reqData),
     });
     const result = await data.json();
-    window.localStorage.setItem("accountname", result.user.accountname);
+    return result.user.accountname;
   } catch (error) {
     console.log(error.message);
   }


### PR DESCRIPTION
## 작업내용
- #11 에서 프로필 수정한 후 계정 ID를 제대로 비교하지 못해서 내 계정이 아닐 때 나오는 팔로우 버튼이 뜨던 문제를 수정했습니다. 
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
