### PR TITLE
Fix: 상품/게시글 삭제 후 프로필 페이지가 업데이트되지 않던 문제 수정

### DIFF
--- a/src/components/modules/PostCard/PostCard.jsx
+++ b/src/components/modules/PostCard/PostCard.jsx
@@ -27,20 +27,20 @@ function ImageListMaker({ image }) {
   );
 }
 
-function PostCard({ post, setDeletePost }) {
+function PostCard({ post }) {
   const navigate = useNavigate();
   const [onModal, setOnModal] = useState(false);
   const { user } = useContext(LoginedUserContext);
   const author = post.author;
   async function handlePostDelete(postId) {
-    await deletePost(postId, setDeletePost);
+    await deletePost(user.token, postId);
     navigate(`/profile/${author.accountname}`);
   }
   function handlePostChange(postId) {
     navigate(`/post/edit/${postId}`);
   }
   async function handlePostReport(postId) {
-    await reportPost(postId);
+    await reportPost(user.token, postId);
   }
   return (
     <>

--- a/src/components/modules/PostCard/PostCardAPI.js
+++ b/src/components/modules/PostCard/PostCardAPI.js
@@ -1,8 +1,7 @@
 import { BASE_URL } from "../../../common/BASE_URL";
-const TOKEN = window.localStorage.getItem("token");
 
 //게시물 삭제
-async function deletePost(postId, setDeletePost) {
+async function deletePost(TOKEN, postId, setDeletePost) {
   try {
     await fetch(BASE_URL + `/post/${postId}`, {
       method: "DELETE",
@@ -18,7 +17,7 @@ async function deletePost(postId, setDeletePost) {
 }
 
 //게시물 신고
-async function reportPost(postId) {
+async function reportPost(TOKEN, postId) {
   try {
     await fetch(BASE_URL + `/post/${postId}/report`, {
       method: "POST",

--- a/src/components/organisms/ProductList/ProductList.jsx
+++ b/src/components/organisms/ProductList/ProductList.jsx
@@ -3,16 +3,18 @@ import Product from "../../modules/Product/Product";
 import styles from "./productList.module.css";
 import Modal from "../Modal/Modal";
 import { deleteProduct } from "./ProductListAPI";
+import { useContext } from "react";
+import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 
-function ProductList({ isMyProfile, products, setDeleteProduct }) {
+function ProductList({ isMyProfile, products }) {
   const [onModal, setOnModal] = useState(false);
   const [link, setLink] = useState("");
   const [productId, setProductId] = useState("");
+  const { user } = useContext(LoginedUserContext);
 
   //상품 게시글 삭제
   async function handleDeletePost(productId) {
-    await deleteProduct(productId);
-    setDeleteProduct(productId);
+    await deleteProduct(user.token, productId);
   }
 
   function handleEditPost() {

--- a/src/components/organisms/ProductList/ProductListAPI.js
+++ b/src/components/organisms/ProductList/ProductListAPI.js
@@ -1,7 +1,6 @@
 import { BASE_URL } from "../../../common/BASE_URL";
-const TOKEN = window.localStorage.getItem("token");
 
-async function deleteProduct(productId) {
+async function deleteProduct(TOKEN, productId) {
   try {
     await fetch(BASE_URL + `/product/${productId}`, {
       method: "DELETE",

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -21,18 +21,16 @@ function ProfilePage() {
   const [products, setProducts] = useState(null);
   const [posts, setPosts] = useState(null);
   const [isAlbum, setAlbum] = useState(false);
-  const [isMyProfile, setIsMyProfile] = useState("");
-  const [isDeletePost, setDeletePost] = useState("");
-  const [isDeleteProduct, setDeleteProduct] = useState("");
+  const [isMyProfile, setMyProfile] = useState(null);
 
   const { user } = useContext(LoginedUserContext);
 
   useEffect(() => {
     // 사용자의 프로필 정보를 받아오는 함수입니다.
     if (user.accountname === accountname) {
-      setIsMyProfile(true);
+      setMyProfile(true);
     } else {
-      setIsMyProfile(false);
+      setMyProfile(false);
     }
     getProfile(user.token, accountname, setProfile);
     getProducts(user.token, accountname, setProducts);
@@ -40,12 +38,16 @@ function ProfilePage() {
   }, [accountname, user]);
 
   useEffect(() => {
+    getProfile(user.token, accountname, setProfile);
+  }, [profile]);
+
+  useEffect(() => {
     getProducts(user.token, accountname, setProducts);
-  }, [isDeleteProduct]);
+  }, [products]);
 
   useEffect(() => {
     getPosts(user.token, accountname, setPosts);
-  }, [isDeletePost]);
+  }, [posts]);
 
   return (
     <section>
@@ -59,7 +61,6 @@ function ProfilePage() {
           <ProductList
             isMyProfile={isMyProfile}
             products={products}
-            setDeleteProduct={setDeleteProduct}
           />
         )}
         {posts && posts.length != 0 && (
@@ -69,7 +70,8 @@ function ProfilePage() {
               <ol>
                 {posts.map((post, index) => (
                   <li key={index}>
-                    <PostCard post={post} setDeletePost={setDeletePost} />
+                    <PostCard post={post}
+                    />
                   </li>
                 ))}
               </ol>


### PR DESCRIPTION
## 작업내용
- #11 에서 상품이나 게시글을 삭제했을 때 프로필 페이지가 업데이트되지 않던 문제를 수정했습니다. (API 내에서 토큰 받아오는 코드를 수정해서 해결)
- isDeleteProduct, isDeletePost를 사용하지 않아도 업데이트되도록 변경하였습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
