### PR TITLE
Feat: 팔로우/언팔로우 기능 추가

### DIFF
--- a/src/common/FollowUser.js
+++ b/src/common/FollowUser.js
@@ -1,0 +1,16 @@
+import { BASE_URL } from "./BASE_URL";
+
+async function followUser(TOKEN, accountname) {
+  try {
+    await fetch(BASE_URL + `/profile/${accountname}/follow`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+export { followUser };

--- a/src/common/UnfollowUser.js
+++ b/src/common/UnfollowUser.js
@@ -1,0 +1,16 @@
+import { BASE_URL } from "./BASE_URL";
+
+async function unfollowUser(TOKEN, accountname) {
+  try {
+    await fetch(BASE_URL + `/profile/${accountname}/unfollow`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+export { unfollowUser };

--- a/src/components/modules/ProfileButton/ProfileButton.jsx
+++ b/src/components/modules/ProfileButton/ProfileButton.jsx
@@ -1,20 +1,32 @@
-import React, { useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Button from "../../atoms/Button/Button";
 import IconButton from "../../atoms/IconButton/IconButton";
+import { followUser } from "../../../common/FollowUser";
+import { unfollowUser } from "../../../common/UnfollowUser";
+import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 import styles from "./profileButton.module.css";
 
-function ProfileButton() {
-  const [isFollowing, setIsFollowing] = useState(false);
+function ProfileButton({ userProfile }) {
+  const { user } = useContext(LoginedUserContext);
+  const [isFollow, setFollow] = useState(userProfile.isfollow);
+
+  useEffect(() => {
+    setFollow(userProfile.isfollow);
+  }, [userProfile.isfollow]);
 
   return (
     <div className={styles["container-button"]}>
       <IconButton type="message" text="메시지 보내기" />
       <Button
         size="medium"
-        label={isFollowing ? "언팔로우" : "팔로우"}
+        label={isFollow ? "언팔로우" : "팔로우"}
         active={true}
-        primary={isFollowing ? false : true}
-        onClick={() => setIsFollowing(!isFollowing)}
+        primary={isFollow ? false : true}
+        onClick={() => {
+          isFollow
+            ? unfollowUser(user.token, userProfile.accountname)
+            : followUser(user.token, userProfile.accountname);
+        }}
       />
       <IconButton type="share" text="공유하기" />
     </div>

--- a/src/components/modules/UserFollow/UserFollow.jsx
+++ b/src/components/modules/UserFollow/UserFollow.jsx
@@ -1,34 +1,51 @@
-import React from "react";
+import React, { useContext, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import ImageBox from "../../atoms/ImageBox/ImageBox";
 import UserNameIntroduce from "../../atoms/UserNameIntroduce/UserNameIntroduce";
 import Button from "../../atoms/Button/Button";
 import styles from "./userFollow.module.css";
-import { useState } from "react";
-import { Link } from "react-router-dom";
+import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
+import { followUser } from "../../../common/FollowUser";
+import { unfollowUser } from "../../../common/UnfollowUser";
 
-function UserFollow({ user }) {
-  const [isFollowing, setIsFollowing] = useState(false);
+function UserFollow({ userProfile }) {
+  const { user } = useContext(LoginedUserContext);
+  const [isFollow, setFollow] = useState(userProfile.isfollow);
+
+  useEffect(() => {
+    setFollow(userProfile.isfollow);
+  }, [userProfile.isfollow]);
+
   return (
     <div className={styles["wrapper-follow"]}>
-        <ImageBox
-          src={user.image}
-          type="circle"
-          size="medium"
-          alt="프로필 이미지"
-        />
-        <Link to={`/profile/${user.accountname}`} className={styles["wrapper-link"]}>
+      <ImageBox
+        src={userProfile.image}
+        type="circle"
+        size="medium"
+        alt="프로필 이미지"
+      />
+      <Link
+        to={`/profile/${userProfile.accountname}`}
+        className={styles["wrapper-link"]}
+      >
         <UserNameIntroduce
-          userName={user.username}
-          userIntroduce={user.intro}
+          userName={userProfile.username}
+          userIntroduce={userProfile.intro}
         />
       </Link>
-      <Button
-        size="small"
-        label={isFollowing ? "취소" : "팔로우"}
-        active={true}
-        primary={isFollowing ? false : true}
-        onClick={() => setIsFollowing(!isFollowing)}
-      />
+      {user.accountname !== userProfile.accountname && (
+        <Button
+          size="small"
+          label={isFollow ? "취소" : "팔로우"}
+          active={true}
+          primary={isFollow ? false : true}
+          onClick={() =>
+            isFollow
+              ? unfollowUser(user.token, userProfile.accountname)
+              : followUser(user.token, userProfile.accountname)
+          }
+        />
+      )}
     </div>
   );
 }

--- a/src/components/organisms/FollowList/FollowList.jsx
+++ b/src/components/organisms/FollowList/FollowList.jsx
@@ -9,7 +9,7 @@ function FollowList({ list }) {
       {list.map((user) => {
         return (
           <li key={user._id}>
-            <UserFollow user={user} />
+            <UserFollow userProfile={user} />
           </li>
         );
       })}

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -18,7 +18,9 @@ function UserProfile({ isMyProfile, userProfile }) {
       {isMyProfile ? (
         <MyProfileButton />
       ) : (
-        <ProfileButton isFollowing={userProfile.isFollowing} />
+        <ProfileButton
+          userProfile={userProfile}
+        />
       )}
     </section>
   );

--- a/src/pages/FollowerPage/FollowerPage.jsx
+++ b/src/pages/FollowerPage/FollowerPage.jsx
@@ -1,11 +1,9 @@
-import React from "react";
-import { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
 import FollowList from "../../components/organisms/FollowList/FollowList";
 import { getFollowers } from "./FollowerPageAPI";
-import { useContext } from "react";
 import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function FollowerPage() {
@@ -16,7 +14,7 @@ function FollowerPage() {
 
   useEffect(() => {
     getFollowers(user.token, accountname, setFollowers);
-  }, [accountname]);
+  }, [accountname, followers]);
 
   return (
     <section>

--- a/src/pages/FollowingPage/FollowingPage.jsx
+++ b/src/pages/FollowingPage/FollowingPage.jsx
@@ -1,5 +1,4 @@
-import React, { useContext } from "react";
-import { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import HeaderForm from "../../components/modules/HeaderForm/HeaderForm";
 import BottomNavigateBar from "../../components/modules/BottomNavigateBar/BottomNavigateBar";
@@ -15,7 +14,7 @@ function FollowingPage() {
 
   useEffect(() => {
     getFollowings(user.token, accountname, setFollowings);
-  }, [accountname]);
+  }, [accountname, followings]);
 
   return (
     <section>


### PR DESCRIPTION
## 작업내용
- #161 을 완료했습니다.
- 팔로우/언팔로우하면 프로필 페이지, 팔로워/팔로잉 페이지에 바로 반영됩니다.
- 팔로워/팔로잉 리스트에 현재 로그인된 계정이 있을 경우 버튼이 출력되지 않습니다.
![image](https://user-images.githubusercontent.com/79434205/181746386-2f6f3ca8-7c72-4432-9145-6898ea34c8d9.png)

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 프로필 페이지와 팔로워/팔로잉 페이지 총 세 개에서 같은 함수를 사용하기 때문에 common 폴더 안에 넣어주었습니다.
- #171 을 머지해야 바뀌는 게 제대로 보입니다.
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
