### PR TITLE
Fix: Image box 경로 잘못되었을 경우 대체이미지 넣기 

### DIFF
--- a/src/components/atoms/ImageBox/ImageBox.jsx
+++ b/src/components/atoms/ImageBox/ImageBox.jsx
@@ -2,9 +2,12 @@ import React from "react";
 import styles from "./imageBox.module.css";
 
 function ImageBox({ src, type, size, alt }) {
+  function handleError(e) {
+    e.target.src = "https://mandarin.api.weniv.co.kr/1659185236635.png";
+  }
   return (
     <div className={`${styles["image"]} ${styles[type]} ${styles[size]}`}>
-      {src && <img src={src} alt={alt} />}
+      {src && <img src={src} alt={alt} onError={handleError} />}
     </div>
   );
 }

--- a/src/components/modules/PostCard/postCard.module.css
+++ b/src/components/modules/PostCard/postCard.module.css
@@ -22,6 +22,7 @@
   font-weight: 400;
   font-size: 1.4rem;
   line-height: normal;
+  word-break: break-all;
 }
 
 .list-images {


### PR DESCRIPTION
## 작업내용
- #166 
- Image box 경로 잘못되었을 경우 엑박 대신 대체이미지를 넣도록 하였습니다. 
- 추가로, PostCard 컴포넌트에서도 글이 길어질 경우 화면을 뚫는 경우가 있어서 해결해주었습니다. 
### 1) 전
![image](https://user-images.githubusercontent.com/68495264/181915601-857064e4-fc5a-490d-b05a-7ea024bc9f6f.png)
### 2) 후
![image](https://user-images.githubusercontent.com/68495264/181915580-e5c02a21-6137-401d-abcf-80a7a87607d9.png)

## 중점적으로 봐주셨으면 하는 부분
- 이미지 경로 예외처리 함수를 만들다가.. 예외처리 경우의 수가 너무 많아서 경로를 불러올 수 없는 경우 모두 대체이미지를 넣도록 설정해주었습니다. 
- 이미지는 임시로 넣어놓았는데, 저번에 혜원님이 만드셨던 울고있는 고양이로나 다른걸로 대체해도 좋을것 같아요!!ㅎㅎㅎ


## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
