### PR TITLE
Design: 모바일에서 프로필 사진과 팔로워/팔로잉 수 사이의 간격이 줄어들게 수정

### DIFF
--- a/src/components/modules/UserProfileBox/userProfileBox.module.css
+++ b/src/components/modules/UserProfileBox/userProfileBox.module.css
@@ -12,3 +12,9 @@
   gap: 42px;
   margin: 0 auto;
 }
+
+@media screen and (max-width: 350px){
+  .wrapper-upper{
+    gap: 22px;
+  }
+}


### PR DESCRIPTION
## 작업내용
- #11 이 모바일(갤럭시 폴드)에서는 사진과 팔로워/팔로잉 수 사이의 간격이 너무 멀어 잘리기 때문에 미디어 쿼리를 추가하였습니다.
수정 전
![image](https://user-images.githubusercontent.com/79434205/181917600-086ec6e5-52dc-42d0-9ea5-02312d00bd01.png)
수정 후
![image](https://user-images.githubusercontent.com/79434205/181917622-d50fc971-7d2e-40d8-8e86-34d61f0e02b0.png)

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
