### PR TITLE
Fix: 존재하지 않는 사용자일 경우 에러 페이지를 보여주도록 수정

### DIFF
--- a/src/components/atoms/NavItem/NavItem.jsx
+++ b/src/components/atoms/NavItem/NavItem.jsx
@@ -6,8 +6,8 @@ function NavItem({link, label, icon}) {
   const currunt = location.pathname === link;
 
   return (
-      <Link 
-        to={link} 
+      <Link
+        to={link}
         className={`${styles.link} ${styles[icon]} ${currunt ? styles.active : null}`}
       >
         <span className={styles.label}>{label}</span>

--- a/src/pages/ProfilePage/ProfilePageAPI.js
+++ b/src/pages/ProfilePage/ProfilePageAPI.js
@@ -10,9 +10,14 @@ async function getProfile(TOKEN, accountname, setProfile) {
       },
     });
     const result = await data.json();
-    setProfile(result.profile);
+    if (result.status === "404") {
+      throw result;
+    } else {
+      setProfile(result.profile);
+    }
   } catch (error) {
     console.log(error.message);
+    return error;
   }
 }
 
@@ -27,6 +32,7 @@ async function getProducts(TOKEN, accountname, setProducts) {
       },
     });
     const result = await data.json();
+
     setProducts(result);
   } catch (error) {
     console.log(error.message);


### PR DESCRIPTION
## 작업내용
- #162 를 해결하여 존재하지 않는 유저의 프로필 페이지로 이동하면 에러 페이지를 보여주도록 했습니다.
![image](https://user-images.githubusercontent.com/79434205/182013345-87366fa4-dd91-4cf0-958f-d1c186f8e6e6.png)

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 정상작동하긴 하는데, 내비게이션 바에서 프로필 버튼을 눌렀을 때는 왠지 모르게 안 먹히더라고요. 새로고침하면 잘 되는데... 추후에 더 수정해 보겠습니다! #186 
- 우선은 에러 페이지 컴포넌트 자체를 보여주고 있는데, /notfound라던가 url을 하나 정해서 거기로 리디렉션해주는 게 나을까요?
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
