### PR TITLE
Feat: 회원 가입 페이지에 비밀번호 확인 추가

### DIFF
--- a/src/components/modules/LoginForm/LoginForm.jsx
+++ b/src/components/modules/LoginForm/LoginForm.jsx
@@ -193,6 +193,11 @@ function LoginForm({
         onChange={handleInputValue}
         error={error.password}
         innerRef={passwordInput}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            label === "로그인" && handleSubmitLogin();
+          }
+        }}
       />
       {label !== "로그인" && (
         <InputBox
@@ -205,7 +210,7 @@ function LoginForm({
           error={error.passwordConfirm}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
-              label === "로그인" ? handleSubmitLogin() : handleCheckEmail();
+              label !== "로그인" && handleCheckEmail();
             }
           }}
         />

--- a/src/components/modules/LoginForm/LoginForm.jsx
+++ b/src/components/modules/LoginForm/LoginForm.jsx
@@ -38,6 +38,10 @@ function LoginForm({
     setError({ ...error, password: "" });
   }, [value.password]);
 
+  useEffect(() => {
+    setError({ ...error, passwordConfirm: "" });
+  }, [value.passwordConfirm]);
+
   // 이메일과 비밀번호 둘 다 input이므로 한꺼번에 관리합니다.
   function handleInputValue(event) {
     setValue({ ...value, [event.target.id]: event.target.value });
@@ -71,6 +75,15 @@ function LoginForm({
       return false;
     }
     // passwordInput.current.focus();
+    return true;
+  }
+
+  function checkPasswordConfirmError() {
+    // 비밀번호와 비밀번호 확인이 다른지 검사
+    if (value.password !== value.passwordConfirm) {
+      setError({ ...error, passwordConfirm: "비밀번호가 일치하지 않습니다." });
+      return false;
+    }
     return true;
   }
 
@@ -142,7 +155,12 @@ function LoginForm({
     emailInput.current.blur();
     passwordInput.current.blur();
     // 에러가 없고 이메일이 유효하다면 context에 이메일, 비밀번호를 저장합니다.
-    if (!error.email && !error.password && isEmailValid) {
+    if (
+      !error.email &&
+      !error.password &&
+      !error.passwordConfirm &&
+      isEmailValid
+    ) {
       setEmailPasswordValid(true); // 이메일과 비밀번호에 문제가 없으면 true로 변경
     }
   }
@@ -175,17 +193,28 @@ function LoginForm({
         onChange={handleInputValue}
         error={error.password}
         innerRef={passwordInput}
-        onKeyDown={(event) => {
-          if (event.key === "Enter") {
-            label === "로그인" ? handleSubmitLogin() : handleCheckEmail();
-          }
-        }}
       />
+      {label !== "로그인" && (
+        <InputBox
+          id="passwordConfirm"
+          type="password"
+          name="비밀번호 확인"
+          value={value.passwordConfirm}
+          onBlur={value.password && checkPasswordConfirmError}
+          onChange={handleInputValue}
+          error={error.passwordConfirm}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              label === "로그인" ? handleSubmitLogin() : handleCheckEmail();
+            }
+          }}
+        />
+      )}
       <Button
         href={null}
         size="large"
         label={label}
-        active={value.email && value.password && true}
+        active={value.email && value.password && value.passwordConfirm && true}
         primary={true}
         onClick={label === "로그인" ? handleSubmitLogin : handleCheckEmail}
       />

--- a/src/pages/RegisterPage/RegisterPage.jsx
+++ b/src/pages/RegisterPage/RegisterPage.jsx
@@ -12,6 +12,7 @@ function RegisterPage() {
     username: "",
     email: "",
     password: "",
+    passwordConfirm: "",
     accountname: "",
     intro: "",
     image: "",
@@ -20,6 +21,7 @@ function RegisterPage() {
   const [error, setError] = useState({
     email: "",
     password: "",
+    passwordConfirm: "",
     username: "",
     accountname: "",
   });


### PR DESCRIPTION
## 작업내용
- #12 에서 #177 를 해결하였습니다.
![image](https://user-images.githubusercontent.com/79434205/182542313-501d557a-c33d-43d0-8b24-48185f81325e.png)

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- LoginForm이 이메일 인풋, 비밀번호 인풋이라 로그인, 회원가입에서 공유하는 컴포넌트였는데 비밀번호 확인이 생기면서 폼이 달라지게 돼서 같은 컴포넌트로 두는 게 맞는지는 모르겠습니다... 하지만 이미 고치기엔 늦은 거 같아서 그냥 기존 컴포넌트에 비밀번호 확인 인풋을 추가했습니다 
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
