### PR TITLE
Fix: 타인의 프로필 페이지에서 하단 바의 프로필 버튼을 눌렀을 때의 오류 수정

### DIFF
--- a/src/components/atoms/NavItem/NavItem.jsx
+++ b/src/components/atoms/NavItem/NavItem.jsx
@@ -1,18 +1,26 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import styles from "./navItem.module.css";
 
-function NavItem({link, label, icon}) {
+function NavItem({ link, label, icon }) {
   // 현재 path가 props로 받아온 링크와 일치하면 currunt는 true
   const currunt = location.pathname === link;
 
   return (
-      <Link
-        to={link}
-        className={`${styles.link} ${styles[icon]} ${currunt ? styles.active : null}`}
-      >
-        <span className={styles.label}>{label}</span>
-      </Link>
-  )
+    <Link
+      to={link}
+      onClick={() => {
+        if (label === "프로필") {
+          window.location.reload();
+          useNavigate(link);
+        }
+      }}
+      className={`${styles.link} ${styles[icon]} ${
+        currunt ? styles.active : null
+      }`}
+    >
+      <span className={styles.label}>{label}</span>
+    </Link>
+  );
 }
 
 export default NavItem;


### PR DESCRIPTION
## 작업내용
- #186 을 수정하였습니다.
## 레퍼런스
- [페이지 새로고침 메서드](https://stackoverflow.com/questions/53420677/react-link-doesnt-refresh-the-page)
- [url의 파라미터만 다른 경우 새로고침되지 않는 문제](https://developpaper.com/question/why-does-react-router-jump-in-the-case-of-the-same-url-and-different-parameters-but-does-not-refresh-the-page/)
## 중점적으로 봐주었으면 하는 부분
- 이슈에 설명된 것처럼 타인의 프로필에서 내 프로필로 이동할 때는 로딩 컴포넌트도 뜨지 않고 버벅이면서 바뀝니다. 도저히 원인을 모르겠어서 프로필일 경우에만 `window.location.reload()` 를 이용하여 새로고침을 한 번 더 해주도록 하였습니다.
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
