### PR TITLE
Fix: 컨텍스트에 정보 저장하기 전 토큰 검증하도록 수정

### DIFF
--- a/src/common/checkValid.js
+++ b/src/common/checkValid.js
@@ -1,0 +1,20 @@
+import { BASE_URL } from "./BASE_URL";
+
+async function checkTokenValid(TOKEN) {
+  try {
+    const data = await fetch(BASE_URL + "/user/checktoken", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        "Content-type": "application/json",
+      },
+    });
+    const result = await data.json();
+    const isValid = await result.isValid;
+    return isValid;
+  } catch (error) {
+    console.log(error.message);
+  }
+}
+
+export { checkTokenValid };

--- a/src/components/molecules/LoginForm/LoginForm.jsx
+++ b/src/components/molecules/LoginForm/LoginForm.jsx
@@ -1,11 +1,12 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { BASE_URL } from "../../../common/BASE_URL";
+import { checkTokenValid } from "../../../common/checkValid";
+import { postLogin } from "../../../pages/LoginPage/LoginPageAPI";
+import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 import InputBox from "../../atoms/InputBox/InputBox";
 import Button from "../../atoms/Button/Button";
 import styles from "./loginForm.module.css";
-import { BASE_URL } from "../../../common/BASE_URL";
-import { postLogin } from "../../../pages/LoginPage/LoginPageAPI";
-import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 
 function LoginForm({
   label,
@@ -104,18 +105,20 @@ function LoginForm({
         });
       } else {
         // 토큰 검증 과정 필요
-
-        // 검증이 끝나면 세션 스토리지에 토큰, 계정 ID, 이미지 저장
-        window.sessionStorage.setItem("token", result.user.token);
-        window.sessionStorage.setItem("accountname", result.user.accountname);
-        window.sessionStorage.setItem("image", result.user.image);
-        const loginedData = {
-          token: window.sessionStorage.getItem("token"),
-          accountname: window.sessionStorage.getItem("accountname"),
-          image: window.sessionStorage.getItem("image"),
-        };
-        setUser(loginedData);
-        navigate("/feed");
+        const isTokenValid = await checkTokenValid(result.user.token);
+        if (isTokenValid) {
+          // 검증이 끝나면 세션 스토리지에 토큰, 계정 ID, 이미지 저장
+          window.sessionStorage.setItem("token", result.user.token);
+          window.sessionStorage.setItem("accountname", result.user.accountname);
+          window.sessionStorage.setItem("image", result.user.image);
+          const loginedData = {
+            token: window.sessionStorage.getItem("token"),
+            accountname: window.sessionStorage.getItem("accountname"),
+            image: window.sessionStorage.getItem("image"),
+          };
+          setUser(loginedData);
+          navigate("/feed");
+        }
       }
     }
   }

--- a/src/pages/SplashPage/SplashPage.jsx
+++ b/src/pages/SplashPage/SplashPage.jsx
@@ -1,15 +1,14 @@
 import React from "react";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 import Logo from "../../assets/logo-main.svg";
 import styles from "./splashPage.module.css";
-import { useNavigate } from "react-router-dom";
-import { useContext } from "react";
-import { LoginedUserContext } from "../../contexts/LoginedUserContext";
 
 function SplashPage() {
   const [visible, setVisible] = useState(false);
   const navigate = useNavigate();
-  const { user, setUser } = useContext(LoginedUserContext);
+  const { user } = useContext(LoginedUserContext);
 
   function handleNavigate() {
     if (!user.token) {
@@ -19,10 +18,9 @@ function SplashPage() {
     }
   }
   useEffect(() => {
-    const loginedData = user;
-    setUser(loginedData);
     setVisible(true);
   }, []);
+
   return (
     <section className={styles["wrapper-splash"]}>
       <h2 className="a11y-hidden">게임어스</h2>


### PR DESCRIPTION
## 작업내용
- #145 를 로그인 시 하도록 수정하였습니다.
- #1 에서 쓸데 없이 setUser를 쓰고 있던 부분을 삭제하였습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 사실 토큰 유효성 검사를 대체 언제 해야 하는 건지 애매해서 미루고 있었는데, (최초 접속 페이지의 경우라면) 토큰을 받아 와서 컨텍스트에 저장할 때 검사하는 것도 괜찮을 것 같다는 답변을 받았습니다.
**원래라면 api 요청에서 토큰이 필요할 때마다 검증하는 것이 적절하다고 하셨습니다.**
- 저는 로그인 시 로그인에 성공하면 세션 스토리지에 정보를 저장하는 동시에 컨텍스트에 저장하도록 코드를 작성했고, 나머지 페이지는 컨텍스트의 정보를 받아오고 있기 때문에 로그인 시에만 검사하고 토큰이 검증되었을 때만 세션스토리지와 컨텍스트에 저장하도록 하였습니다.
(사실 로그인 시에 받아오는 토큰은 잘못되거나 만료될 일이 없으니 이게 맞나 싶기도 합니다)
- 토큰이 유효성 검사에 통과되지 않았을 경우에는 어떤 동작을 하게 해야 하는지 몰라서 따로 else로 적어주지 못했습니다.
- 파일명이 checkValid인 이유는 토큰 검증 외에 이메일, 계정 ID 검증 부분도 이 파일로 옮기려고 하기 때문입니다.
## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
