### PR TITLE
Design: PostCard 컴포넌트의 프로필 사진 링크 범위 수정

### DIFF
--- a/src/components/molecules/PostCard/postCard.module.css
+++ b/src/components/molecules/PostCard/postCard.module.css
@@ -10,6 +10,7 @@
 
 .profile {
   grid-row: 1 / -1;
+  height: fit-content;
 }
 
 .container-user {


### PR DESCRIPTION
## 작업내용
- #159 를 프로필 사진 크기에 맞게 수정하였습니다.
![image](https://user-images.githubusercontent.com/79434205/184126884-fd8aac70-a4cc-4b93-b03f-1a4edc78e542.png)

## 레퍼런스

## 중점적으로 봐주었으면 하는 부분
- 간단해서 그냥 제가 고쳤는데 괜찮으시죠?
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
