### PR TITLE
Fix: 토큰 검증이 안 되었을 때 confirm 창 출력되게 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import SplashPage from "./pages/SplashPage/SplashPage";
 import HomePage from "./pages/HomePage/HomePage";
 import LoginPage from "./pages/LoginPage/LoginPage";
@@ -32,58 +32,73 @@ function App() {
     accountname: loginedAccountname,
     image: loginedImage,
   });
+  const location = useLocation();
+  // const [isTokenValid, setTokenValid] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
-    if (checkTokenValid(user.token)) {
-      const loginedData = user;
-      setUser(loginedData);
+    async function tokenCheck() {
+      const result = await checkTokenValid(user.token);
+      if (
+        (user.token === null || !result) &&
+        location.pathname !== "/" &&
+        location.pathname !== "/login" &&
+        location.pathname !== "/register"
+      ) {
+        const answer = window.confirm(
+          "로그인이 필요한 서비스입니다.\n로그인 페이지로 이동하시겠습니까?"
+        );
+        answer ? navigate("/login") : navigate("/");
+      } else {
+        const loginedData = user;
+        setUser(loginedData);
 
-      if (window.performance) {
-        if (PerformanceNavigationTiming === 1) {
-          setUser(loginedData);
+        if (window.performance) {
+          if (PerformanceNavigationTiming === 1) {
+            setUser(loginedData);
+          }
         }
       }
     }
-  }, []);
+    tokenCheck();
+  }, [user.token]);
 
   return (
     <LoginedUserContext.Provider value={{ user, setUser }}>
-      {user && (
-        <div className="max-width">
-          <h1 className="a11y-hidden">게임어스</h1>
-          <Routes>
-            <Route path="/" element={<SplashPage />} />
-            <Route path="/feed" element={<HomePage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/search" element={<SearchPage />} />
-            <Route path="/chat" element={<ChatListPage />} />
-            <Route path="/chat/:chatroomId" element={<ChatRoomPage />} />
-            <Route path="/post" element={<PostUploadPage />} />
-            <Route path="/post/:postId" element={<PostViewPage />} />
-            <Route path="/post/edit/:postId" element={<PostEditPage />} />
-            <Route path="/profile/:accountname" element={<ProfilePage />} />
-            <Route
-              path="/profile/:accountname/edit"
-              element={<ProfileEditPage />}
-            />
-            <Route
-              path="/profile/:accountname/follower"
-              element={<FollowerPage />}
-            />
-            <Route
-              path="/profile/:accountname/following"
-              element={<FollowingPage />}
-            />
-            <Route path="/product" element={<ProductUploadPage />} />
-            <Route
-              path="/product/edit/:productId"
-              element={<ProductEditPage />}
-            />
-            <Route path="/*" element={<ErrorPage />} />
-          </Routes>
-        </div>
-      )}
+      <div className="max-width">
+        <h1 className="a11y-hidden">게임어스</h1>
+        <Routes>
+          <Route path="/" element={<SplashPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/feed" element={<HomePage />} />
+          <Route path="/search" element={<SearchPage />} />
+          <Route path="/chat" element={<ChatListPage />} />
+          <Route path="/chat/:chatroomId" element={<ChatRoomPage />} />
+          <Route path="/post" element={<PostUploadPage />} />
+          <Route path="/post/:postId" element={<PostViewPage />} />
+          <Route path="/post/edit/:postId" element={<PostEditPage />} />
+          <Route path="/profile/:accountname" element={<ProfilePage />} />
+          <Route
+            path="/profile/:accountname/edit"
+            element={<ProfileEditPage />}
+          />
+          <Route
+            path="/profile/:accountname/follower"
+            element={<FollowerPage />}
+          />
+          <Route
+            path="/profile/:accountname/following"
+            element={<FollowingPage />}
+          />
+          <Route path="/product" element={<ProductUploadPage />} />
+          <Route
+            path="/product/edit/:productId"
+            element={<ProductEditPage />}
+          />
+          <Route path="/*" element={<ErrorPage />} />
+        </Routes>
+      </div>
     </LoginedUserContext.Provider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,7 +33,6 @@ function App() {
     image: loginedImage,
   });
   const location = useLocation();
-  // const [isTokenValid, setTokenValid] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/src/common/checkValid.js
+++ b/src/common/checkValid.js
@@ -10,6 +10,9 @@ async function checkTokenValid(TOKEN) {
       },
     });
     const result = await data.json();
+    if(result.status === 401){
+      return false;
+    }
     const isValid = await result.isValid;
     return isValid;
   } catch (error) {


### PR DESCRIPTION
## 작업내용
- close #210 
토큰이 없거나 검증이 안 되었을 때, 스플래시, 로그인, 회원가입 페이지를 제외한 페이지에서 confirm 창이 출력되도록 수정하였습니다.
![image](https://user-images.githubusercontent.com/79434205/184785796-e6b64861-eb97-4d34-97bc-2620152dc871.png)
확인 버튼을 누르면 로그인 페이지로, 취소 버튼을 누르면 스플래시 페이지로 이동하게 하였습니다.
## 레퍼런스
- [리액트에서 현재 페이지 pathname 가져오기](https://stackoverflow.com/questions/42253277/react-router-v4-how-to-get-current-route)
- [alert, prompt, confirm이 두 번 출력되는 이유](https://stackoverflow.com/questions/66263996/react-app-my-alert-window-is-showing-up-twice)
## 중점적으로 봐주었으면 하는 부분
- 레퍼런스에서 적은 것처럼 `React.StrictMode`가 있으면 렌더링을 두 번 해서 알림창이 두 번 뜨게 된다고 합니다. 그래서 우선 index.js의 strictmode 부분을 주석처리했는데, 혹시 해결 방안을 찾으면 다시 strictmode를 살리겠습니다!
## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [x]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
