### PR TITLE
Refactor: 팔로우/언팔로우 과정 수정

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "game-us-404"
+  }
+}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm ci && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,5 @@
 {
   "hosting": {
-    "site": "gameus",
     "public": "build",
     "ignore": [
       "firebase.json",

--- a/src/common/FollowUser.js
+++ b/src/common/FollowUser.js
@@ -1,17 +1,18 @@
 import { BASE_URL } from "./BASE_URL";
 
-async function followUser(TOKEN, accountname, setChangeFollow) {
+async function followUser(TOKEN, accountname) {
   try {
-    await fetch(BASE_URL + `/profile/${accountname}/follow`, {
+    const data = await fetch(BASE_URL + `/profile/${accountname}/follow`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${TOKEN}`,
         "Content-type": "application/json",
       },
     });
+    const result = await data.json();
+    return result;
   } catch (error) {
     console.log(error.message);
   }
-  setChangeFollow(accountname + "true");
 }
 export { followUser };

--- a/src/common/UnfollowUser.js
+++ b/src/common/UnfollowUser.js
@@ -1,17 +1,18 @@
 import { BASE_URL } from "./BASE_URL";
 
-async function unfollowUser(TOKEN, accountname, setChangeFollow) {
+async function unfollowUser(TOKEN, accountname) {
   try {
-    await fetch(BASE_URL + `/profile/${accountname}/unfollow`, {
+    const data = await fetch(BASE_URL + `/profile/${accountname}/unfollow`, {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${TOKEN}`,
         "Content-type": "application/json",
       },
     });
+    const result = await data.json();
+    return result;
   } catch (error) {
     console.log(error.message);
   }
-  setChangeFollow(accountname + "false");
 }
 export { unfollowUser };

--- a/src/components/molecules/ProfileButton/ProfileButton.jsx
+++ b/src/components/molecules/ProfileButton/ProfileButton.jsx
@@ -1,19 +1,25 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useState } from "react";
 import Button from "../../atoms/Button/Button";
 import IconButton from "../../atoms/IconButton/IconButton";
 import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 import { followUser } from "../../../common/FollowUser";
 import { unfollowUser } from "../../../common/UnfollowUser";
-import { getProfile } from "../../../pages/ProfilePage/ProfilePageAPI";
 import styles from "./profileButton.module.css";
 
-function ProfileButton({ userProfile, setProfile, setChangeFollow }) {
+function ProfileButton({ userProfile, setProfile }) {
   const { user } = useContext(LoginedUserContext);
   const [isFollow, setFollow] = useState(userProfile.isfollow);
 
-  useEffect(() => {
-    setFollow(userProfile.isfollow);
-  }, [userProfile.isfollow]);
+  async function handleSetFollow() {
+    let result;
+    if (isFollow) {
+      result = await unfollowUser(user.token, userProfile.accountname);
+    } else {
+      result = await followUser(user.token, userProfile.accountname);
+    }
+    setFollow(result.profile.isfollow);
+    setProfile(result.profile);
+  }
 
   return (
     <div className={styles["container-button"]}>
@@ -23,14 +29,7 @@ function ProfileButton({ userProfile, setProfile, setChangeFollow }) {
         label={isFollow ? "언팔로우" : "팔로우"}
         active={true}
         primary={isFollow ? false : true}
-        onClick={() => {
-          if (isFollow) {
-            unfollowUser(user.token, userProfile.accountname, setChangeFollow);
-          } else {
-            followUser(user.token, userProfile.accountname, setChangeFollow);
-          }
-          getProfile(user.token, userProfile.accountname, setProfile);
-        }}
+        onClick={handleSetFollow}
       />
       <IconButton type="share" text="공유하기" />
     </div>

--- a/src/components/molecules/UserFollow/UserFollow.jsx
+++ b/src/components/molecules/UserFollow/UserFollow.jsx
@@ -1,28 +1,26 @@
-import React, { useContext, useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import React, { useContext, useState } from "react";
+import { Link } from "react-router-dom";
 import Button from "../../atoms/Button/Button";
 import ImageBox from "../../atoms/ImageBox/ImageBox";
 import UserNameIntroduce from "../../atoms/UserNameIntroduce/UserNameIntroduce";
 import { LoginedUserContext } from "../../../contexts/LoginedUserContext";
 import { followUser } from "../../../common/FollowUser";
 import { unfollowUser } from "../../../common/UnfollowUser";
-import { getFollowers } from "../../../pages/FollowerPage/FollowerPageAPI";
-import { getFollowings } from "../../../pages/FollowingPage/FollowingPageAPI";
 import styles from "./userFollow.module.css";
 
-function UserFollow({
-  userProfile,
-  setFollowers,
-  setFollowings,
-  setChangeFollow,
-}) {
+function UserFollow({ userProfile }) {
   const { user } = useContext(LoginedUserContext);
   const [isFollowing, setFollowing] = useState(userProfile.isfollow);
-  let { accountname } = useParams();
 
-  useEffect(() => {
-    setFollowing(userProfile.isfollow);
-  }, [userProfile.isfollow]);
+  async function handleSetFollow() {
+    let result;
+    if (isFollowing) {
+      result = await unfollowUser(user.token, userProfile.accountname);
+    } else {
+      result = await followUser(user.token, userProfile.accountname);
+    }
+    setFollowing(result.profile.isfollow);
+  }
 
   return (
     <div className={styles["wrapper-follow"]}>
@@ -47,18 +45,7 @@ function UserFollow({
           label={isFollowing ? "취소" : "팔로우"}
           active={true}
           primary={isFollowing ? false : true}
-          onClick={() => {
-            if (isFollowing) {
-              unfollowUser(user.token, userProfile.accountname, setChangeFollow);
-            } else {
-              followUser(user.token, userProfile.accountname, setChangeFollow);
-            }
-            if (setFollowers) {
-              getFollowers(user.token, accountname, setFollowers);
-            } else {
-              getFollowings(user.token, accountname, setFollowings);
-            }
-          }}
+          onClick={handleSetFollow}
         />
       )}
     </div>

--- a/src/components/organisms/UserProfile/UserProfile.jsx
+++ b/src/components/organisms/UserProfile/UserProfile.jsx
@@ -4,12 +4,7 @@ import ProfileButton from "../../molecules/ProfileButton/ProfileButton";
 import UserProfileBox from "../../molecules/UserProfileBox/UserProfileBox";
 import styles from "./userProfile.module.css";
 
-function UserProfile({
-  isMyProfile,
-  userProfile,
-  setProfile,
-  setChangeFollow,
-}) {
+function UserProfile({ isMyProfile, userProfile, setProfile }) {
   return (
     <section className={styles["wrapper-profile"]}>
       <UserProfileBox
@@ -23,11 +18,7 @@ function UserProfile({
       {isMyProfile ? (
         <MyProfileButton />
       ) : (
-        <ProfileButton
-          userProfile={userProfile}
-          setProfile={setProfile}
-          setChangeFollow={setChangeFollow}
-        />
+        <ProfileButton userProfile={userProfile} setProfile={setProfile} />
       )}
     </section>
   );

--- a/src/pages/FollowerPage/FollowerPage.jsx
+++ b/src/pages/FollowerPage/FollowerPage.jsx
@@ -12,11 +12,15 @@ function FollowerPage() {
   let { accountname } = useParams();
   const [followers, setFollowers] = useState(null);
   const { user } = useContext(LoginedUserContext);
-  const [isChangeFollow, setChangeFollow] = useState("");
 
   useEffect(() => {
-    getFollowers(user.token, accountname, setFollowers);
-  }, [accountname, isChangeFollow]);
+    async function setFollowerList() {
+      const followerList = await getFollowers(user.token, accountname);
+      setFollowers(followerList);
+    }
+
+    setFollowerList();
+  }, [accountname]);
 
   return (
     <section>
@@ -28,15 +32,7 @@ function FollowerPage() {
         menuButton={false}
       />
       <div className="wrapper-contents">
-        {followers ? (
-          <FollowList
-            list={followers}
-            setFollowers={setFollowers}
-            setChangeFollow={setChangeFollow}
-          />
-        ) : (
-          <Loading />
-        )}
+        {followers ? <FollowList list={followers} /> : <Loading />}
       </div>
       <BottomNavigateBar />
     </section>

--- a/src/pages/FollowerPage/FollowerPageAPI.js
+++ b/src/pages/FollowerPage/FollowerPageAPI.js
@@ -1,6 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-async function getFollowers(TOKEN, accountname, setFollowers) {
+async function getFollowers(TOKEN, accountname) {
   try {
     const data = await fetch(
       BASE_URL + `/profile/${accountname}/follower?limit=Infinity`,
@@ -13,8 +13,7 @@ async function getFollowers(TOKEN, accountname, setFollowers) {
       }
     );
     const result = await data.json();
-    setFollowers(result);
-    console.log("rendering...");
+    return result;
   } catch (error) {
     console.log(error.message);
   }

--- a/src/pages/FollowingPage/FollowingPage.jsx
+++ b/src/pages/FollowingPage/FollowingPage.jsx
@@ -12,11 +12,15 @@ function FollowingPage() {
   let { accountname } = useParams();
   const [followings, setFollowings] = useState(null);
   const { user } = useContext(LoginedUserContext);
-  const [isChangeFollow, setChangeFollow] = useState("");
 
   useEffect(() => {
-    getFollowings(user.token, accountname, setFollowings);
-  }, [accountname, isChangeFollow]);
+    async function setFollowingList() {
+      const followingList = await getFollowings(user.token, accountname);
+      setFollowings(followingList);
+    }
+
+    setFollowingList();
+  }, [accountname]);
 
   return (
     <section>
@@ -28,15 +32,7 @@ function FollowingPage() {
         menuButton={false}
       />
       <div className="wrapper-contents">
-        {followings ? (
-          <FollowList
-            list={followings}
-            setFollowings={setFollowings}
-            setChangeFollow={setChangeFollow}
-          />
-        ) : (
-          <Loading />
-        )}
+        {followings ? <FollowList list={followings} /> : <Loading />}
       </div>
       <BottomNavigateBar />
     </section>

--- a/src/pages/FollowingPage/FollowingPageAPI.js
+++ b/src/pages/FollowingPage/FollowingPageAPI.js
@@ -1,6 +1,6 @@
 import { BASE_URL } from "../../common/BASE_URL";
 
-async function getFollowings(TOKEN, accountname, setFollowings) {
+async function getFollowings(TOKEN, accountname) {
   try {
     const data = await fetch(
       BASE_URL + `/profile/${accountname}/following?limit=Infinity`,
@@ -13,8 +13,7 @@ async function getFollowings(TOKEN, accountname, setFollowings) {
       }
     );
     const result = await data.json();
-    setFollowings(result);
-    console.log("rendering...");
+    return result;
   } catch (error) {
     console.log(error.message);
   }

--- a/src/pages/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage.jsx
@@ -18,7 +18,6 @@ function ProfilePage() {
   const [products, setProducts] = useState(null);
   const [posts, setPosts] = useState(null);
   const [isMyProfile, setMyProfile] = useState(null);
-  const [isChangeFollow, setChangeFollow] = useState("");
 
   const { user } = useContext(LoginedUserContext);
 
@@ -45,7 +44,7 @@ function ProfilePage() {
       }
     }
     setUserProfile();
-  }, [accountname, user, isChangeFollow]);
+  }, [accountname, user]);
 
   return (
     <section>
@@ -61,7 +60,6 @@ function ProfilePage() {
                 isMyProfile={isMyProfile}
                 userProfile={profile}
                 setProfile={setProfile}
-                setChangeFollow={setChangeFollow}
               />
               <ProductList
                 isMyProfile={isMyProfile}


### PR DESCRIPTION
## 작업내용
- 팔로우/언팔로우 시 컴포넌트가 바뀌는 부분을 수정했습니다.
(`[isChangeFollow, setChangeFollow]` state를 없애고 useEffect 삭제, 핸들러 함수 분리)
- 팔로워, 팔로잉 리스트를 받아오는 함수 안에서 setState하는 대신 result를 리턴하여 해당 컴포넌트에서 setState하도록 변경하였습니다.
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분

## check📝
- [ ]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
