### PR TITLE
Fix: 사이트 이름으로 deploy되도록 파이어베이스 설정 파일 수정

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "hosting": {
     "public": "build",
+    "site": "gameus",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
## 작업내용
- 깃허브 액션 설정하다가 기존의 설정이 누락되어 배포가 제대로 되고 있지 않던 점을 수정했습니다.
(중복 때문에 프로젝트 이름(game-us-404)과 사이트 이름(gameus)을 다르게 해 놓았었는데, 설정하면서 `site` 부분이 날아가서 프로젝트 이름의 도메인으로 잘못 배포되고 있었습니다.)
## 레퍼런스

## 중점적으로 봐주었으면 하는 부분

## check📝
- [x]  PR 하나에 기능 하나만 넣었나요?
- [ ]  PR에 이슈를 링크했나요?
- [x]  의미 있는 커밋 메시지를 작성하셨나요?
